### PR TITLE
Add csv extention to report exports

### DIFF
--- a/app/controllers/admin/report_exports_controller.rb
+++ b/app/controllers/admin/report_exports_controller.rb
@@ -4,7 +4,7 @@ module Admin
     def show
       csv = run_exporter(params[:report])
       respond_to do |format|
-        format.csv { send_data csv, filename: params[:report] }
+        format.csv { send_data csv, filename: "#{params[:report]}.csv" }
       end
     end
 


### PR DESCRIPTION
This was driving me crazy during some testing. These should be .csv files like the other report exports.