### PR TITLE
Don't specify domain on contact_us link

### DIFF
--- a/app/views/shared/_sub_nav.html.erb
+++ b/app/views/shared/_sub_nav.html.erb
@@ -11,6 +11,6 @@
     <% end %>
     <%= link_to "Develop Your Own Courses", "https://training.digitallearn.org/trainings/designing-digitallearn-courses" %>
     <span class="spacer">|</span>
-    <%= link_to "Contact Us", new_contact_url(subdomain: "www") %>
+    <%= link_to "Contact Us", new_contact_url %>
   </div>
 </div>


### PR DESCRIPTION
The link only shows at contact/new, which already redirects the user to www