### PR TITLE
Only fire lesson complete event on lesson_complete message

### DIFF
--- a/app/assets/javascripts/lessons.js
+++ b/app/assets/javascripts/lessons.js
@@ -19,7 +19,9 @@ $(document).ready(function() {
   };
 
   handleLessonCompleted = function(event) {
-    sendLessonCompletedEvent();
+    if (event.data === "lesson_completed") {
+      sendLessonCompletedEvent();
+    }
   };
 
   window.addEventListener("message", handleLessonCompleted, true);

--- a/lib/s3_proxy.rb
+++ b/lib/s3_proxy.rb
@@ -16,10 +16,9 @@ class S3Proxy < Rack::Proxy
       # This is the only path that needs to be set currently on Rails 5 & greater
       env['PATH_INFO'] = request.fullpath
 
-      Rails.logger.debug("SERVER_PORT: #{env['SERVER_PORT']}")
-
       # don't send your sites cookies to target service, unless it is a trusted internal service that can parse all your cookies
       env['HTTP_COOKIE'] = ''
+
       super(env)
     else
       @app.call(env)


### PR DESCRIPTION
Some browser plugins use `postMessage`, so we need to make sure the only message that fires the lesson complete event is the "lesson_complete" message.