### PR TITLE
Update javascript when unzipping storylines

### DIFF
--- a/spec/lib/unzipper_spec.rb
+++ b/spec/lib/unzipper_spec.rb
@@ -24,4 +24,12 @@ RSpec.describe Unzipper do
     Unzipper.new(lesson.story_line, temp_root).unzip_lesson
     expect(File.join(temp_root, "#{storyline_path}/#{package_file_name}")).to_not be(nil)
   end
+
+  it 'replaces javascript' do
+    Unzipper.new(lesson.story_line, temp_root).unzip_lesson
+    js_filename = File.join(temp_root, storyline_path, package_file_name, 'story_content', 'user.js')
+    expect(File.read(js_filename)).to_not include("getDLCTransition('lesson')")
+    expect(File.read(js_filename)).to_not include('window.parent.sendLessonCompletedEvent()')
+    expect(File.read(js_filename)).to include('window.parent.postMessage("lesson_completed", "*")')
+  end
 end


### PR DESCRIPTION
The existing zip files are using outdated lesson triggers. This should replace the old ones with the new during the unzipping process, to avoid having to fix and re-upload all the storyline files.