### PR TITLE
Explicitly trim library card number on login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -78,12 +78,17 @@ class User < ApplicationRecord
 
   def self.find_for_database_authentication(warden_conditions)
     conditions = warden_conditions.dup
+    conditions.map do |k, v|
+      conditions[k] = v&.downcase&.strip
+    end
+
     subdomain = conditions.delete(:subdomain).gsub(/\.|stage/, '')
     subdomain = 'www' if subdomain.blank?
 
     conditions[:organization_id] = Organization.find_by(subdomain: subdomain)&.id
+
     if (login = conditions.delete(:login))
-      where(conditions.to_h).where(['library_card_number = :value OR email = :value', { value: login.downcase }]).first
+      where(conditions.to_h).where(['library_card_number = :value OR email = :value', { value: login }]).first
     elsif conditions.key?(:library_card_number) || conditions.key?(:email)
       where(conditions.to_h).first
     end

--- a/spec/features/user/account_settings_spec.rb
+++ b/spec/features/user/account_settings_spec.rb
@@ -151,15 +151,12 @@ feature 'Registered user visits account pages' do
 
   context 'belongs to custom branch organization', js: true do
     let(:org) { FactoryBot.create(:organization, branches: true, accepts_custom_branches: true) }
-    let(:library_location1) { FactoryBot.create(:library_location) }
-    let(:library_location2) { FactoryBot.create(:library_location) }
+    let!(:library_location1) { FactoryBot.create(:library_location, organization: org) }
+    let!(:library_location2) { FactoryBot.create(:library_location, organization: org) }
     let(:profile) { FactoryBot.build(:profile, library_location: library_location1) }
     let(:user) { FactoryBot.create(:user, organization: org, profile: profile) }
 
     before(:each) do
-      org.library_locations << library_location1
-      org.library_locations << library_location2
-
       switch_to_subdomain(org.subdomain)
       log_in_with(user.email, user.password)
 

--- a/spec/features/user/library_card_login_spec.rb
+++ b/spec/features/user/library_card_login_spec.rb
@@ -75,6 +75,12 @@ feature 'User registration and login with library card number' do
       expect(current_path).to eq(new_user_session_path)
       expect(page).to have_content('Invalid Library Card Number or Library Card PIN')
     end
+
+    scenario 'attempts to log in with extra spaces' do
+      library_card_log_in_with(" #{user.library_card_number}  ", user.library_card_pin)
+      expect(current_path).to eq(root_path)
+      expect(page).to_not have_content('Signed in successfully.')
+    end
   end
 
   context 'spanish language user' do


### PR DESCRIPTION
Because we have a custom `User.find_for_database_authentication` method, we need to strip & downcase the login keys there, instead of relying on Devise config.