### PR TITLE
Don't upload unreachable lesson material

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -60,7 +60,6 @@ module Admin
           new_lesson.story_line = nil
           new_lesson.story_line = imported_lesson.story_line
           new_lesson.save!
-          Unzipper.new(new_lesson.story_line).unzip_lesson
         end
 
         # Create copies of the attachments

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -33,7 +33,7 @@ class Course < ApplicationRecord
   # has_one :assessment
   has_one :course_progress, dependent: :restrict_with_exception
 
-  has_many :course_topics, dependent: :restrict_with_exception
+  has_many :course_topics, dependent: :destroy
   has_many :topics, through: :course_topics
   has_many :lessons, dependent: :destroy
   belongs_to :organization, optional: false


### PR DESCRIPTION
Lessons that are imported have a `parent_lesson`. When a `parent_lesson` is present, the lesson content served to users is that of the parent. Therefore, we don't need to upload lesson content for imported lessons, since that content is unreachable under normal circumstances.

I also changed the `course_topics` dependent option, so that courses can be destroyed as needed (and the delete will cascade to corresponding `course_topics` join table entries).