### PR TITLE
Don't require storyline file path for child lessons

### DIFF
--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -2,15 +2,15 @@
 
 module LessonsHelper
   def asl_iframe(lesson)
-    if lesson.story_line_file_name
-      if lesson.parent_id
-        lesson_id = lesson.parent_id
-        directory = Lesson.find(lesson.parent_id).story_line_file_name.chomp('.zip')
-      else
-        lesson_id = lesson.id
-        directory = lesson.story_line_file_name.chomp('.zip')
-      end
+    if lesson.parent
+      lesson_id = lesson.parent_id
+      directory = lesson.parent.story_line_file_name.chomp('.zip')
+    elsif lesson.story_line_file_name
+      lesson_id = lesson.id
+      directory = lesson.story_line_file_name.chomp('.zip')
+    end
 
+    if directory.present?
       story_line_url = "/storylines/#{lesson_id}/#{directory}/story.html"
       content_tag(:iframe, nil, src: story_line_url.to_s, class: 'story_line', title: lesson.summary, id: 'asl-iframe')
     else

--- a/spec/helpers/lessons_helper_spec.rb
+++ b/spec/helpers/lessons_helper_spec.rb
@@ -5,10 +5,20 @@ require 'rails_helper'
 describe LessonsHelper do
 
   let(:lesson) { FactoryBot.create(:lesson) }
+  let(:child_lesson) { FactoryBot.create(:lesson_without_story, parent: lesson) }
+  let(:no_storyline_lesson) { FactoryBot.create(:lesson_without_story) }
 
   describe '#asl_iframe' do
     it 'includes lesson summary as title' do
       expect(helper.asl_iframe(lesson)).to match("title=\"#{lesson.summary}\"")
+    end
+
+    it 'creates iframe from child lesson with no storyline file' do
+      expect(helper.asl_iframe(child_lesson)).to have_selector('iframe')
+    end
+
+    it 'does not create iframe from non-child lesson with no storyline file' do
+      expect(helper.asl_iframe(no_storyline_lesson)).to_not have_selector('iframe')
     end
   end
 


### PR DESCRIPTION
The child lessons should read storyline files from their parents.