### PR TITLE
Use expected parameter name for partner selection

### DIFF
--- a/app/views/devise/registrations/_partners_registration_form.html.erb
+++ b/app/views/devise/registrations/_partners_registration_form.html.erb
@@ -1,4 +1,4 @@
 <div class="form-group">
-  <%= f.label :partner, t("login_signup.choose_partner"), class: 'signup-label' %>
-  <%= f.collection_select :partner, current_organization.partners, :id, :name, include_blank: t("login_signup.partner_placeholder") %>
+  <%= f.label :partner_id, t("login_signup.choose_partner"), class: 'signup-label' %>
+  <%= f.collection_select :partner_id, current_organization.partners, :id, :name, include_blank: t("login_signup.partner_placeholder") %>
 </div>

--- a/spec/features/user/partner_registration_spec.rb
+++ b/spec/features/user/partner_registration_spec.rb
@@ -23,5 +23,6 @@ feature 'User registers and selects a partner' do
     click_button 'Sign Up'
 
     expect(current_path).to eq(profile_path)
+    expect(User.last.reload.partner).to eq(partner)
   end
 end


### PR DESCRIPTION
The `RegistrationsController` expects `partner_id`, not `partner`.