### PR TITLE
Hotfix/translation patch

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,9 @@ class HomeController < ApplicationController
   end
 
   def language_toggle
-    session[:locale] = params['lang']
+    requested_locale = params['lang']
+    whitelisted_locales = I18n.available_locales.map(&:to_s)
+    session[:locale] = requested_locale if whitelisted_locales.include?(requested_locale)
     redirect_back(fallback_location: root_path)
   end
 end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -14,3 +14,6 @@ unless defined?(Rake::Application)
     I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
   end
 end
+
+I18n.available_locales = [:en, :es]
+I18n.default_locale = :en

--- a/config/initializers/new_framework_defaults_5_2.rb
+++ b/config/initializers/new_framework_defaults_5_2.rb
@@ -17,7 +17,7 @@
 # It's best enabled when your entire app is migrated and stable on 5.2.
 #
 # Existing cookies will be converted on read then written with the new scheme.
-# Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
+Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
 
 # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
 # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.


### PR DESCRIPTION
Someone was systematically setting their `session[:locale]` variable (via the `/home_language_toggle` route) to malicious values in a SQL injection attempt. We should only allow this session variable to be changed to valid locales.

This also turns on ES-256-GCM authenticated encryption for cookies to improve cookie security.