### PR TITLE
Shave lesson and course tiles on text size change

### DIFF
--- a/app/assets/javascripts/bind_resize_event.js
+++ b/app/assets/javascripts/bind_resize_event.js
@@ -1,0 +1,7 @@
+function bindResizeEvent($el, height) {
+  $el.on("textresize", function() {
+    $el.shave(height);
+    $(this).unbind("textresize");
+    bindResizeEvent($(this), height);
+  });
+}

--- a/app/assets/javascripts/course_tile.js
+++ b/app/assets/javascripts/course_tile.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
-  var $el = $(".lesson-title");
-  var height = 50;
+  var $el = $(".course-title");
+  var height = 75;
   $el.shave(height);
   bindResizeEvent($el, height);
 });

--- a/app/assets/javascripts/plugins/jquery-textresize-event.js
+++ b/app/assets/javascripts/plugins/jquery-textresize-event.js
@@ -1,0 +1,47 @@
+(function($, window) {
+  var interval = 200,
+    FALSE = !1,
+    CHILD = "tr-child",
+    HEIGHT = "tr-height",
+    TIMER = "tr-timer";
+
+  var detect = function(element, child) {
+    element.data(HEIGHT, child.height());
+
+    return function() {
+      if (element.data(HEIGHT) !== child.height()) {
+        element.data(HEIGHT, child.height()).triggerHandler("textresize");
+      }
+    };
+  };
+
+  $.event.special.textresize = {
+    setup: function() {
+      var element = $(this),
+        child = $("<span>&nbsp</span>")
+          .css({ display: "inline", left: "-9999px", position: "absolute" })
+          .appendTo(this == window ? "body" : element),
+        timer = window.setInterval(detect(element, child), interval);
+
+      element.data(CHILD, child).data(TIMER, timer);
+      return FALSE;
+    },
+    teardown: function() {
+      var element = $(this);
+
+      window.clearInterval(element.data(TIMER));
+      element.data(CHILD).remove();
+      element
+        .removeData(CHILD)
+        .removeData(HEIGHT)
+        .removeData(TIMER);
+
+      return FALSE;
+    }
+  };
+
+  $.fn.textresize = function(fn) {
+    $(this).bind("textresize", fn);
+    return this;
+  };
+})(jQuery, window);

--- a/app/assets/stylesheets/mixins/_course_widget.scss
+++ b/app/assets/stylesheets/mixins/_course_widget.scss
@@ -36,7 +36,6 @@
       font-weight: 300;
       margin: 0em 0.5em;
       padding: 0.4em 0.5em 0.5em 0.25em;
-      height: 45px;
       text-align: left;
       line-height: 1.2em;
     }

--- a/app/views/shared/courses/_listing.html.erb
+++ b/app/views/shared/courses/_listing.html.erb
@@ -13,7 +13,7 @@
       <a class="course-widget<% if courses_completed.include?(c.id) %> completed<% end %>"
           href="<%= course_path(c) %>" data-cpl-ga-event="on" data-cpl-ga-value="user-open-course">
           <header>
-            <h3><%= c.title %></h3>
+            <h3 class='course-title'><%= c.title %></h3>
           </header>
           <div class="description">
             <p><%= c.summary %></p>


### PR DESCRIPTION
Course and lesson titles should both get truncated with different browser font size preference changes. The truncation should happen both on page load and on text resize.