### PR TITLE
Fix library card invitation acceptance bug

### DIFF
--- a/app/controllers/admin/invites_controller.rb
+++ b/app/controllers/admin/invites_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class InvitesController < Devise::InvitationsController
-    before_action :enable_sidebar
+    before_action :enable_sidebar, except: [:edit]
     before_action :skip_authorization, only: %i[edit update]
 
     def new

--- a/app/views/shared/user/_sidebar.html.erb
+++ b/app/views/shared/user/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div class="sidebar">
   <ul class="sidebar-links">
     <li><%= link_to "#{t('account.profile')}", profile_path %></li>
-    <% if !current_organization.library_card_login? || current_user.has_role?(:admin, current_organization) %>
+    <% if !current_organization.library_card_login? || current_user&.has_role?(:admin, current_organization) %>
       <li><%= link_to "#{t('account.login_information')}", account_path %></li>
     <% end %>
     <li><%= link_to "#{t('account.my_completed_courses')}", course_completions_path %></li>

--- a/spec/controllers/admin/invites_controller_spec.rb
+++ b/spec/controllers/admin/invites_controller_spec.rb
@@ -40,13 +40,18 @@ describe Admin::InvitesController do
   describe '#edit' do
     before do
       @invited_user = AdminInvitationService.invite(email: 'test_invite@example.com', organization: organization, inviter: admin)
+      @token = @invited_user.raw_invitation_token
       sign_out admin
     end
 
     it 'should have an ok response' do
-      token = @invited_user.raw_invitation_token
-      get :edit, params: { invitation_token: token }
+      get :edit, params: { invitation_token: @token }
       expect(response).to have_http_status(:ok)
+    end
+
+    it 'should not show sidebar' do
+      get :edit, params: { invitation_token: @token }
+      expect(assigns(:show_sidebar)).to be_falsey
     end
   end
 

--- a/spec/features/admin/accept_invitation_spec.rb
+++ b/spec/features/admin/accept_invitation_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'feature_helper'
+
+feature 'Admin accepts invitation' do
+  context 'library card login user' do
+    let(:library_card_org) { FactoryBot.create(:organization, :library_card_login, subdomain: 'lco') }
+
+    before do
+      switch_to_subdomain(library_card_org.subdomain)
+
+      @invited_user = AdminInvitationService.invite(email: 'test_invite@example.com', organization: library_card_org)
+    end
+
+    it 'should have an ok response' do
+      token = @invited_user.raw_invitation_token
+      visit "/users/invitation/accept?invitation_token=#{token}"
+      expect(page).to have_content('Set your password')
+    end
+  end
+end


### PR DESCRIPTION
The sidebar shouldn't be rendered on invitation acceptance (user must set password before they are logged in).