### PR TITLE
Attach textresize event to window, not individual elements

### DIFF
--- a/app/assets/javascripts/bind_resize_event.js
+++ b/app/assets/javascripts/bind_resize_event.js
@@ -1,7 +1,0 @@
-function bindResizeEvent($el, height) {
-  $el.on("textresize", function() {
-    $el.shave(height);
-    $(this).unbind("textresize");
-    bindResizeEvent($(this), height);
-  });
-}

--- a/app/assets/javascripts/course_tile.js
+++ b/app/assets/javascripts/course_tile.js
@@ -1,6 +1,0 @@
-$(document).ready(function() {
-  var $el = $(".course-title");
-  var height = 75;
-  $el.shave(height);
-  bindResizeEvent($el, height);
-});

--- a/app/assets/javascripts/lesson_tile.js
+++ b/app/assets/javascripts/lesson_tile.js
@@ -1,6 +1,0 @@
-$(document).ready(function() {
-  var $el = $(".lesson-title");
-  var height = 50;
-  $el.shave(height);
-  bindResizeEvent($el, height);
-});

--- a/app/assets/javascripts/shaveable.js
+++ b/app/assets/javascripts/shaveable.js
@@ -1,0 +1,12 @@
+$(document).ready(function() {
+  var $el = $(".shaveable");
+
+  if ($el.length) {
+    var height = $el.data("resize-height");
+    $el.shave(height);
+
+    $(window).on("textresize", function() {
+      $el.shave(height);
+    });
+  }
+});

--- a/app/views/shared/courses/_course_widget.html.erb
+++ b/app/views/shared/courses/_course_widget.html.erb
@@ -1,6 +1,6 @@
 <a class="course-widget<% if courses_completed.include?(course.id) %> completed<% end %>" href="<%= course_path(course) %>" data-cpl-ga-event="on" data-cpl-ga-value="user-open-course">
   <header>
-    <h3 class='course-title'><%= course.title %></h3>
+    <h3 class='course-title shaveable' data-resize-height="75"><%= course.title %></h3>
   </header>
   <div class="description">
     <p><%= course.summary %></p>

--- a/app/views/shared/lessons/_lesson_tile.html.erb
+++ b/app/views/shared/lessons/_lesson_tile.html.erb
@@ -4,7 +4,7 @@
   <% else %>
     <span class="lesson-order"><%= lesson.published_lesson_order %></span>
   <% end %>
-  <span class="lesson-title"><%= lesson.title %></span>
+  <span class="lesson-title shaveable" data-resize-height="50"><%= lesson.title %></span>
 </div>
 <div class="lesson-tile-body">
   <div class="duration-info">


### PR DESCRIPTION
The lesson title resize event was causing problems with the display of the drag & drop ghost. I don't know the exact nature of the interference between those two features, but I think it had something to do with the hidden element that the `textresize` event uses to detect resize events. When this was connected to elements used in the drag & drop, it caused weird behavior. Moving the resize detector to the window element eliminates the issue.