### PR TITLE
Set contact email model validation to correct length

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -6,7 +6,7 @@ class Contact < ApplicationRecord
   validates :organization, presence: true, length: { maximum: 50 }
   validates :city, presence: true, length: { maximum: 30 }
   validates :state, presence: true, length: { maximum: 2 }
-  validates :email, presence: true, length: { maximum: 50 }
+  validates :email, presence: true, length: { maximum: 30 }
   validates :email, email: true, if: proc { |c| c.email.present? }
   validates :phone, length: { maximum: 20 }
   validates :comments, presence: true, length: { maximum: 2048 }

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -81,6 +81,12 @@ describe ContactsController do
       expect(response).to render_template :new
     end
 
+    it 'handles long emails gracefulle' do
+      long_email = "tom+long_email_address@ckdtech.co"
+      post :create, params: { contact: valid_attributes.merge(email: long_email) }
+      expect(response).to render_template :new
+    end
+
   end
 
 end


### PR DESCRIPTION
The contact email database column has a limit of 30 characters.