### PR TITLE
Remove unused GET sign_up route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,8 @@ Rails.application.routes.draw do
     invitations: 'admin/invites',
     sessions: 'sessions',
     passwords: 'passwords'
+  }, path_names: {
+    sign_up: ''
   }
 
   devise_scope :user do


### PR DESCRIPTION
Registration form is on a shared login/signup page. Registration create is still allowed, but the /sign_up route is not used in the app, but it gets hit by webcrawlers, etc. all the time