### PR TITLE
Fix category propagation

### DIFF
--- a/spec/controllers/admin/courses_controller_spec.rb
+++ b/spec/controllers/admin/courses_controller_spec.rb
@@ -240,7 +240,7 @@ describe Admin::CoursesController do
 
         before do
           course2.update(organization: org2, parent_id: course1.id)
-          course1.propagation_org_ids = [org2.id]
+          course1.update(propagation_org_ids: [org2])
         end
 
         it 'propagates changes to selected courses' do
@@ -264,6 +264,28 @@ describe Admin::CoursesController do
           expect do
             patch :update, params: update_params
           end.to_not(change { category2.courses.count })
+        end
+
+        describe 'new category' do
+          let(:new_category_params) do
+            { id: course1.to_param,
+              course: { category_id: '0',
+                        category_attributes: { name: 'New Category', organization_id: org.id },
+                        propagation_org_ids: [org2.id] },
+              commit: 'Save Course' }
+          end
+
+          it 'should create a new category in originating org' do
+            expect do
+              patch :update, params: new_category_params
+            end.to change { org.categories.count }.by(1)
+          end
+
+          it 'should create a new category in subsite org' do
+            expect do
+              patch :update, params: new_category_params
+            end.to change { org2.categories.count }.by(1)
+          end
         end
       end
     end

--- a/spec/factories/programs.rb
+++ b/spec/factories/programs.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :program do
-    program_name { Faker::App.name }
+    program_name { Faker::Lorem.words(number: 4).join(' ') }
     location_required { false }
     parent_type { Program.parent_types['seniors'] }
     organization { create(:organization, :accepts_programs) }

--- a/spec/models/course/course_spec.rb
+++ b/spec/models/course/course_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe Course do
   let(:course) { FactoryBot.create(:course) }
+  let(:org) { course.organization }
 
   describe 'scopes' do
     describe '#pla' do
@@ -13,6 +14,36 @@ describe Course do
 
       it 'should return www courses only' do
         expect(Course.pla).to contain_exactly(pla_course)
+      end
+    end
+  end
+
+  describe 'category' do
+    it 'should create org category based on category name' do
+      expect do
+        course.update(category_name: 'New Category')
+      end.to change { org.categories.count }.by(1)
+    end
+
+    describe 'existing category' do
+      let!(:category) { FactoryBot.create(:category, organization: org, name: 'Existing Category') }
+
+      it 'should not create a new category' do
+        expect do
+          course.update(category_name: category.name)
+        end.to_not change { org.categories.count }
+      end
+
+      it 'should add course to existing category' do
+        expect do
+          course.update(category_name: category.name)
+        end.to change { category.courses.count }.by(1)
+      end
+
+      it 'should add course to existing category in case-insensitive manner' do
+        expect do
+          course.update(category_name: "eXisting categorY")
+        end.to change { category.courses.count }.by(1)
       end
     end
   end


### PR DESCRIPTION
We are going to remove Course update propagation soon, so this is quick and dirty, but it fixes a propagation related bug, where propagating a Category change would point subsite courses at www categories, instead of the corresponding category for the subsite organization.