### PR TITLE
Imported course attachments

### DIFF
--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -150,7 +150,7 @@ module Admin
     end
 
     def attributes_to_propagate
-      course_params.except(:category_id, :category_attributes, :access_level, :course_topics_attributes)
+      course_params.except(:category_id, :category_attributes, :access_level, :course_topics_attributes, :attachments_attributes)
     end
 
     def update_course

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -73,7 +73,7 @@ module Admin
 
       if update_course
         if @course.parent.blank?
-          CoursePropagationService.new(course: @course, attributes_to_propagate: attributes_to_propagate).propagate_course_changes
+          CoursePropagationService.new(course: @course).propagate_course_changes(attributes_to_propagate)
           success_message = 'Course was successfully updated.'
         end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AttachmentsController < ApplicationController
+  def show
+    @attachment = Attachment.find(params[:id])
+    authorize @attachment, :show?
+
+    extension = File.extname(@attachment.document_file_name)
+    file_options = if extension == '.pdf'
+                     { disposition: 'inline', type: 'application/pdf', x_sendfile: true }
+                   else
+                     { disposition: 'attachment', type: ['application/msword',
+                                                         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                                                         'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+                       x_sendfile: true }
+                   end
+    send_file @attachment.document.path, file_options
+  end
+end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -48,22 +48,6 @@ class CoursesController < ApplicationController
     end
   end
 
-  def view_attachment
-    @course = Course.friendly.find(params[:course_id])
-    authorize @course, :show?
-
-    extension = File.extname(@course.attachments.find(params[:attachment_id]).document_file_name)
-    file_options = if extension == '.pdf'
-                     { disposition: 'inline', type: 'application/pdf', x_sendfile: true }
-                   else
-                     { disposition: 'attachment', type: ['application/msword',
-                                                         'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-                                                         'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
-                       x_sendfile: true }
-                   end
-    send_file @course.attachments.find(params[:attachment_id]).document.path, file_options
-  end
-
   def skills
     @course = Course.friendly.find(params[:course_id])
     authorize @course, :show?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -135,11 +135,11 @@ class Course < ApplicationRecord
   end
 
   def post_course_attachments
-    self.attachments.where(doc_type: 'post-course')
+    (parent || self).attachments.where(doc_type: 'post-course')
   end
 
   def supplemental_attachments
-    self.attachments.where(doc_type: 'supplemental')
+    (parent || self).attachments.where(doc_type: 'supplemental')
   end
 
   def published?

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -1,9 +1,28 @@
 # frozen_string_literal: true
 
 class AttachmentPolicy < AdminOnlyPolicy
+
+  def show?
+    course_to_authorize = child_course || record.course
+
+    CoursePolicy.new(user, course_to_authorize).show?
+  end
+
   private
 
   def organization
     record.course.organization
+  end
+
+  def child_courses
+    Course.copied_from_course(record.course)
+  end
+
+  def child_course
+    child_courses.where(organization_id: user.organization.id).first
+  end
+
+  def attachment_current_course
+    child_course || record.course
   end
 end

--- a/app/services/course_import_service.rb
+++ b/app/services/course_import_service.rb
@@ -11,7 +11,6 @@ class CourseImportService
     ActiveRecord::Base.transaction do
       save_new_course!
       copy_parent_lessons!
-      copy_attachments!
       copy_topics!
     end
 
@@ -49,16 +48,6 @@ class CourseImportService
       new_lesson.course_id = @new_course.id
       new_lesson.story_line = nil
       new_lesson.save!
-    end
-  end
-
-  def copy_attachments!
-    # Create copies of the attachments
-    @parent_course.attachments.each do |attachment|
-      new_attachment = attachment.dup
-      new_attachment.document = attachment.document
-      new_attachment.course_id = @new_course.id
-      new_attachment.save!
     end
   end
 

--- a/app/services/course_propagation_service.rb
+++ b/app/services/course_propagation_service.rb
@@ -2,14 +2,13 @@
 
 class CoursePropagationService
 
-  def initialize(course:, attributes_to_propagate:)
+  def initialize(course:)
     @course = course
-    @attributes_to_propagate = attributes_to_propagate
   end
 
-  def propagate_course_changes
+  def propagate_course_changes(attributes_to_propagate)
     child_courses.each do |child|
-      child.update(@attributes_to_propagate.merge(topics: topics))
+      child.update(attributes_to_propagate.merge(topics: topics))
     end
   end
 

--- a/app/views/shared/courses/_supplemental_materials.html.erb
+++ b/app/views/shared/courses/_supplemental_materials.html.erb
@@ -2,7 +2,7 @@
 <% if @course.post_course_attachments.count > 0 %>
   <ul class="no-padding">
   <% @course.post_course_attachments.each do |a| %>
-    <%= link_to course_attachment_path(@course, a), target: "_blank", class: "block_link" do %>
+    <%= link_to attachment_path(a), target: "_blank", class: "block_link" do %>
       <li class="attachment-download">
         <i class="icon-download"></i>
         <%= a.document_file_name %>

--- a/app/views/shared/courses/_text_copies.html.erb
+++ b/app/views/shared/courses/_text_copies.html.erb
@@ -2,7 +2,7 @@
 <% if @course.supplemental_attachments.count > 0 %>
   <ul class="no-padding">
   <% @course.supplemental_attachments.each do |a| %>
-    <%= link_to course_attachment_path(@course, a), target: "_blank", class: "block_link" do %>
+    <%= link_to attachment_path(a), target: "_blank", class: "block_link" do %>
       <li class="attachment-download" data-cpl-ga-event="on" data-cpl-ga-value="supplemental-material-download" data-document-name='<%= "#{a.document_file_name}" %>'>
         <i class="icon-download"></i>
         <%= a.document_file_name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,13 +23,14 @@ Rails.application.routes.draw do
 
   resources :courses, only: [:index, :show] do
     post 'start'
-    get 'attachment/:attachment_id' => 'courses#view_attachment', as: :attachment
     get 'skills', to: 'courses#skills', as: :skills
     resources :lessons, only: [:index, :show] do
       get 'lesson_complete'
       post 'complete'
     end
   end
+
+  resources :attachments, only: [:show]
 
   resources :my_courses, only: [:index], param: :course_id
 

--- a/db/data/20200325204512_remove_child_course_attachments.rb
+++ b/db/data/20200325204512_remove_child_course_attachments.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveChildCourseAttachments < ActiveRecord::Migration[5.2]
+  def up
+    Course.where.not(parent: nil).each do |course|
+      course.attachments.destroy_all
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-DataMigrate::Data.define(version: 20_191_205_164_530)
+DataMigrate::Data.define(version: 20_200_325_204_512)

--- a/spec/controllers/admin/courses_controller/update_spec.rb
+++ b/spec/controllers/admin/courses_controller/update_spec.rb
@@ -96,6 +96,33 @@ describe Admin::CoursesController do
           end.to_not(change { child_course.reload.access_level })
         end
 
+        describe 'attachments' do
+          let(:document) { fixture_file_upload(Rails.root.join('spec', 'fixtures', 'testfile.pdf'), 'application/pdf') }
+
+          let(:attachment_attributes) do
+            { attachments_attributes: {
+              '0' => {
+                document: document,
+                title: '',
+                doc_type: 'post-course',
+                file_description: 'post-course attachment test'
+              }
+            } }
+          end
+
+          it 'adds attachments to parent course' do
+            expect do
+              patch :update, params: { id: pla_course.to_param, course: attachment_attributes }
+            end.to change { pla_course.attachments.count }.by(1)
+          end
+
+          it 'does not propagate attachments to child course' do
+            expect do
+              patch :update, params: { id: pla_course.to_param, course: attachment_attributes }
+            end.to_not(change { child_course.attachments.count })
+          end
+        end
+
         describe 'new category' do
           let(:new_category_params) do
             { id: pla_course.to_param,

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe AttachmentsController do
+  let(:pla) { FactoryBot.create(:default_organization) }
+  let(:pla_course) { FactoryBot.create(:course, organization: pla) }
+  let(:subsite_course) { FactoryBot.create(:course, parent: pla_course) }
+  let(:subsite) { subsite_course.organization }
+  let(:subsite_user) { FactoryBot.create(:user, organization: subsite) }
+  let(:other_subsite_user) { FactoryBot.create(:user) }
+
+  let(:document) { fixture_file_upload(Rails.root.join('spec', 'fixtures', 'testfile.pdf'), 'application/pdf') }
+  let(:attachment) { FactoryBot.create(:attachment, document: document, course: pla_course) }
+
+  describe '#show' do
+    context 'visitor on subsite' do
+      before do
+        request.host = "#{subsite.subdomain}.example.com"
+      end
+
+      it 'allows the visitor to view an attachment' do
+        get :show, params: { id: attachment.id }
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'does not allow visitor to view attachment if course is private' do
+        subsite_course.update!(access_level: 'authenticated_users')
+        get :show, params: { id: attachment.id }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'user on subsite' do
+      before do
+        request.host = "#{subsite.subdomain}.example.com"
+        sign_in subsite_user
+      end
+
+      it 'allows the user to view an attachment' do
+        get :show, params: { id: attachment.id }
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'allows user to view attachment if course is private' do
+        subsite_course.update!(access_level: 'authenticated_users')
+        get :show, params: { id: attachment.id }
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'user on another subsite' do
+      before do
+        request.host = "#{other_subsite_user.organization.subdomain}.example.com"
+        sign_in other_subsite_user
+      end
+
+      it 'does not allow user to view attachment' do
+        get :show, params: { id: attachment.id }
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -81,30 +81,6 @@ describe CoursesController do
     end
   end
 
-  describe 'GET #view_attachment' do
-    context 'when logged in' do
-      before(:each) do
-        sign_in user
-      end
-
-      it 'allows the user to view an uploaded file' do
-        file = fixture_file_upload(Rails.root.join('spec', 'fixtures', 'testfile.pdf'), 'application/pdf')
-        course1.attachments.create(document: file, doc_type: 'post-course')
-        get :view_attachment, params: { course_id: course1, attachment_id: course1.attachments.first.id }
-        expect(response).to have_http_status(:success)
-      end
-    end
-
-    context 'when not logged in' do
-      it 'should allow view' do
-        file = fixture_file_upload(Rails.root.join('spec', 'fixtures', 'testfile.pdf'), 'application/pdf')
-        course1.attachments.create(document: file, doc_type: 'post-course')
-        get :view_attachment, params: { course_id: course1, attachment_id: course1.attachments.first.id }
-        expect(response).to have_http_status(:success)
-      end
-    end
-  end
-
   describe 'GET #skills' do
     context 'when logged in' do
       before(:each) do

--- a/spec/models/course/course_spec.rb
+++ b/spec/models/course/course_spec.rb
@@ -180,4 +180,32 @@ describe Course do
       expect(archived_course.published?).to be_falsey
     end
   end
+
+  describe 'attachments' do
+    let(:pla) { FactoryBot.create(:default_organization) }
+    let(:pla_course) { FactoryBot.create(:course, organization: pla) }
+    let(:child_course) { FactoryBot.create(:course, parent: pla_course) }
+    let!(:post_course_attachment) { FactoryBot.create(:attachment, doc_type: 'post-course', course: pla_course) }
+    let!(:supplemental_attachment) { FactoryBot.create(:attachment, doc_type: 'supplemental', course: pla_course) }
+
+    context 'parent course' do
+      it 'returns correct #post_course_attachments' do
+        expect(pla_course.post_course_attachments).to contain_exactly(post_course_attachment)
+      end
+
+      it 'returns correct #supplemental_attachments' do
+        expect(pla_course.supplemental_attachments).to contain_exactly(supplemental_attachment)
+      end
+    end
+
+    context 'child course' do
+      it 'returns correct #post_course_attachments' do
+        expect(child_course.post_course_attachments).to contain_exactly(post_course_attachment)
+      end
+
+      it 'returns correct #supplemental_attachments' do
+        expect(child_course.supplemental_attachments).to contain_exactly(supplemental_attachment)
+      end
+    end
+  end
 end

--- a/spec/policies/attachment_policy_spec.rb
+++ b/spec/policies/attachment_policy_spec.rb
@@ -10,5 +10,64 @@ RSpec.describe AttachmentPolicy, type: :policy do
   let!(:subsite_record) { FactoryBot.create(:attachment, course: course) }
   let!(:other_subsite_record) { FactoryBot.create(:attachment) }
 
-  it_behaves_like 'AdminOnly Policy', { skip_scope: true }
+  it_behaves_like 'AdminOnly Policy', { skip_scope: true, skip_actions: [:show?] }
+
+  permissions :show? do
+    let(:pla) { FactoryBot.create(:default_organization) }
+    let(:pla_user) { FactoryBot.create(:user, organization: pla) }
+
+    let(:subsite) { FactoryBot.create(:organization) }
+    let(:subsite_user) { FactoryBot.create(:user, organization: subsite) }
+
+    let(:guest_user) { GuestUser.new(organization: subsite) }
+
+    let(:pla_course) { FactoryBot.create(:course, organization: pla) }
+    let!(:child_course) { FactoryBot.create(:course, organization: subsite, parent: pla_course) }
+
+    let(:attachment) { FactoryBot.create(:attachment, course: pla_course) }
+    let(:other_course_attachment) { FactoryBot.create(:attachment) }
+
+    subject { described_class }
+
+    context 'guest user' do
+      it 'should be permitted' do
+        expect(subject).to permit(guest_user, attachment)
+      end
+
+      it 'should not be permitted for attachment not related to subsite course' do
+        expect(subject).to_not permit(guest_user, other_course_attachment)
+      end
+
+      it 'should not be permitted for private course attachment' do
+        child_course.update!(access_level: 'authenticated_users')
+        expect(subject).to_not permit(guest_user, attachment)
+      end
+    end
+
+    context 'original course user' do
+      it 'should be permitted for current organization' do
+        expect(subject).to permit(pla_user, attachment)
+      end
+
+      it 'should be permitted for private course' do
+        child_course.update!(access_level: 'authenticated_users')
+        expect(subject).to permit(pla_user, attachment)
+      end
+    end
+
+    context 'authenticated user' do
+      it 'should be permitted for current organization' do
+        expect(subject).to permit(subsite_user, attachment)
+      end
+
+      it 'should not be permitted for another organization' do
+        expect(subject).to_not permit(subsite_user, other_course_attachment)
+      end
+
+      it 'should be permitted for private course' do
+        child_course.update!(access_level: 'authenticated_users')
+        expect(subject).to permit(subsite_user, attachment)
+      end
+    end
+  end
 end

--- a/spec/services/course_import_service_spec.rb
+++ b/spec/services/course_import_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CourseImportService do
+  let(:pla) { FactoryBot.create(:default_organization) }
+  let(:topic) { FactoryBot.create(:topic) }
+  let(:category) { FactoryBot.create(:category, organization: pla) }
+  let(:pla_course) { FactoryBot.create(:course_with_lessons, organization: pla, topics: [topic], category: category) }
+
+  let(:document) { fixture_file_upload(Rails.root.join('spec', 'fixtures', 'testfile.pdf'), 'application/pdf') }
+  let!(:attachment) { FactoryBot.create(:attachment, document: document, course: pla_course) }
+
+  let(:subsite) { FactoryBot.create(:organization) }
+
+  subject { described_class.new(organization: subsite, course_id: pla_course.id) }
+
+  it 'should create a new course record for subsite' do
+    expect do
+      subject.import!
+    end.to change { subsite.courses.count }.by(1)
+  end
+
+  it 'should create new course as a child of original course' do
+    expect do
+      subject.import!
+    end.to change { Course.copied_from_course(pla_course).count }.by(1)
+  end
+
+  it 'should import course in draft status' do
+    expect do
+      subject.import!
+    end.to change { Course.where(pub_status: 'D').count }.by(1)
+  end
+
+  it 'should create new category on organization' do
+    expect do
+      subject.import!
+    end.to change { subsite.categories.count }.by(1)
+  end
+
+  it 'should copy lessons into organization' do
+    expect do
+      subject.import!
+    end.to change { subsite.lessons.count }.by(3)
+  end
+
+  it 'should not copy attachments' do
+    expect do
+      subject.import!
+    end.to_not change(Attachment, :count)
+  end
+
+  it 'should create new course topic' do
+    expect do
+      subject.import!
+    end.to change(CourseTopic, :count).by(1)
+  end
+end

--- a/spec/services/course_propagation_service_spec.rb
+++ b/spec/services/course_propagation_service_spec.rb
@@ -24,10 +24,10 @@ describe CoursePropagationService do
       }
     end
 
-    subject { described_class.new(course: course, attributes_to_propagate: new_attributes) }
+    subject { described_class.new(course: course) }
 
     it 'should update child course info' do
-      subject.propagate_course_changes
+      subject.propagate_course_changes(new_attributes)
       child_course.reload
       new_attributes.keys.each do |k|
         expect(child_course.send(k)).to eq(new_attributes[k])
@@ -56,23 +56,23 @@ describe CoursePropagationService do
       }
     end
 
-    subject { described_class.new(course: course, attributes_to_propagate: attachment_attributes) }
+    subject { described_class.new(course: course) }
 
     it 'should update child attachments' do
       expect do
-        subject.propagate_course_changes
+        subject.propagate_course_changes(attachment_attributes)
       end.to change { child_course.attachments.count }.by(2)
     end
 
     it 'should add a post-course attachment' do
       expect do
-        subject.propagate_course_changes
+        subject.propagate_course_changes(attachment_attributes)
       end.to change { child_course.post_course_attachments.count }.by(1)
     end
 
     it 'should add a supplemental attachment' do
       expect do
-        subject.propagate_course_changes
+        subject.propagate_course_changes(attachment_attributes)
       end.to change { child_course.supplemental_attachments.count }.by(1)
     end
   end
@@ -84,10 +84,10 @@ describe CoursePropagationService do
       course.update(topics: [topic])
     end
 
-    subject { described_class.new(course: course, attributes_to_propagate: {}) }
+    subject { described_class.new(course: course) }
 
     it 'should add correct topic to child course' do
-      subject.propagate_course_changes
+      subject.propagate_course_changes({})
       expect(child_course.reload.topics).to contain_exactly(topic)
     end
   end

--- a/spec/services/course_propagation_service_spec.rb
+++ b/spec/services/course_propagation_service_spec.rb
@@ -8,87 +8,47 @@ describe CoursePropagationService do
   let(:old_topic) { FactoryBot.create(:topic) }
   let!(:child_course) { FactoryBot.create(:course, parent: course, topics: [old_topic]) }
 
-  describe 'model attribute changes' do
-    let(:new_attributes) do
-      {
-        title: 'New Course Title',
-        contributor: 'New Contributor',
-        summary: 'New Summary',
-        description: 'New Description',
-        notes: 'New Notes',
-        language: @spanish,
-        format: 'M',
-        level: 'Advanced',
-        seo_page_title: 'New SEO Title',
-        meta_desc: 'New Meta Desc'
-      }
-    end
+  describe '#propagate_course_changes' do
+    describe 'model attribute changes' do
+      let(:new_attributes) do
+        {
+          title: 'New Course Title',
+          contributor: 'New Contributor',
+          summary: 'New Summary',
+          description: 'New Description',
+          notes: 'New Notes',
+          language: @spanish,
+          format: 'M',
+          level: 'Advanced',
+          seo_page_title: 'New SEO Title',
+          meta_desc: 'New Meta Desc'
+        }
+      end
 
-    subject { described_class.new(course: course) }
+      subject { described_class.new(course: course) }
 
-    it 'should update child course info' do
-      subject.propagate_course_changes(new_attributes)
-      child_course.reload
-      new_attributes.keys.each do |k|
-        expect(child_course.send(k)).to eq(new_attributes[k])
+      it 'should update child course info' do
+        subject.propagate_course_changes(new_attributes)
+        child_course.reload
+        new_attributes.keys.each do |k|
+          expect(child_course.send(k)).to eq(new_attributes[k])
+        end
       end
     end
-  end
 
-  describe 'attachment update' do
-    let(:attachment) { fixture_file_upload(Rails.root.join('spec', 'fixtures', 'testfile.pdf'), 'application/pdf') }
-    let(:attachment_attributes) do
-      {
-        attachments_attributes: {
-          '0' => {
-            document: attachment,
-            title: 'Test post-course attachment',
-            doc_type: 'post-course',
-            file_description: 'post-course attachment test'
-          },
-          '1' => {
-            document: attachment,
-            title: 'Test supplemental attachment',
-            doc_type: 'supplemental',
-            file_description: 'supplemental attachment test'
-          }
-        }
-      }
-    end
+    describe 'topic changes' do
+      let!(:topic) { FactoryBot.create(:topic) }
 
-    subject { described_class.new(course: course) }
+      before do
+        course.update(topics: [topic])
+      end
 
-    it 'should update child attachments' do
-      expect do
-        subject.propagate_course_changes(attachment_attributes)
-      end.to change { child_course.attachments.count }.by(2)
-    end
+      subject { described_class.new(course: course) }
 
-    it 'should add a post-course attachment' do
-      expect do
-        subject.propagate_course_changes(attachment_attributes)
-      end.to change { child_course.post_course_attachments.count }.by(1)
-    end
-
-    it 'should add a supplemental attachment' do
-      expect do
-        subject.propagate_course_changes(attachment_attributes)
-      end.to change { child_course.supplemental_attachments.count }.by(1)
-    end
-  end
-
-  describe 'topic changes' do
-    let!(:topic) { FactoryBot.create(:topic) }
-
-    before do
-      course.update(topics: [topic])
-    end
-
-    subject { described_class.new(course: course) }
-
-    it 'should add correct topic to child course' do
-      subject.propagate_course_changes({})
-      expect(child_course.reload.topics).to contain_exactly(topic)
+      it 'should add correct topic to child course' do
+        subject.propagate_course_changes({})
+        expect(child_course.reload.topics).to contain_exactly(topic)
+      end
     end
   end
 end


### PR DESCRIPTION
Instead of trying to propagate attachments, this displays the parent course attachments for imported courses, like we do with storyline files.

The data migration removes all imported course attachments, which are no longer needed.