### PR TITLE
Replace publication status select on course forms

### DIFF
--- a/app/assets/stylesheets/components/_course_form.scss
+++ b/app/assets/stylesheets/components/_course_form.scss
@@ -17,13 +17,14 @@
     "course_level access_level"
     "seo_title seo_title"
     "seo_meta seo_meta"
-    "propagation propagation"
+    "pub_status ."
     "actions actions";
 
   &.restricted {
     grid-template-areas:
       "errors errors"
       "categories access_level"
+      "pub_status ."
       "actions actions"
       "title title"
       "author author"
@@ -34,10 +35,9 @@
       "additional_content additional_content"
       "topics ."
       "language format"
-      "course_level pub_status"
+      "course_level ."
       "seo_title seo_title"
-      "seo_meta seo_meta"
-      "propagation propagation";
+      "seo_meta seo_meta";
   }
 
   .error_explanation {
@@ -114,6 +114,10 @@
 
   .seo-meta {
     grid-area: seo_meta;
+  }
+
+  .pub-status {
+    grid-area: pub_status;
   }
 
   .propagation {

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -102,6 +102,13 @@
     <div class="character-limit note left-or-right">&nbsp;</div>
   </fieldset>
 
+  <fieldset class='pub-status'>
+    <%= f.label :pub_status, class: "text-color" do %>
+      Publication Status
+    <% end %>
+    <%= f.select(:pub_status, options_for_select([["Draft", "D"], ["Published", "P"], ["Archived", "A"]], @course.pub_status), data: { status: @course.pub_status }) %>
+  </fieldset>
+
   <%= f.hidden_field :subdomain, value: current_organization.subdomain %>
   <%= f.hidden_field :organization_id, value: current_organization.id %>
 

--- a/app/views/admin/courses/forms/_course_owner_actions.html.erb
+++ b/app/views/admin/courses/forms/_course_owner_actions.html.erb
@@ -1,5 +1,4 @@
   <div class="form-actions spread actions">
-    <%= f.submit "Publish Course", class: "button-color" %>
-    <%= f.submit "Save as Draft", class: "button-color" %>
+    <%= f.submit "Save Course", class: "button-color" %>
     <%= f.submit "Save & Edit Lessons", class: "button-color" %>
   </div>

--- a/app/views/admin/courses/forms/_imported_course_actions.html.erb
+++ b/app/views/admin/courses/forms/_imported_course_actions.html.erb
@@ -1,5 +1,5 @@
   <div class="form-actions spread actions">
-    <%= f.submit "Publish", params: { commit: "Publish" }, class: "button-color" %>
+    <%= f.submit "Save Course", class: "button-color" %>
     <p><i>
       If you wish to edit details of this course and use the PLA-created Storyline files, please <%= mail_to "support@digitallearn.org", "contact a PLA Administrator" %>.
     </i></p>

--- a/spec/controllers/admin/courses_controller/create_spec.rb
+++ b/spec/controllers/admin/courses_controller/create_spec.rb
@@ -74,6 +74,12 @@ describe Admin::CoursesController do
       it 'redirects to the admin edit view of the course' do
         post :create, params: { course: valid_attributes }
         expect(response).to have_http_status(:redirect)
+        expect(response).to redirect_to(edit_admin_course_path(Course.find_by(title: valid_attributes[:title])))
+      end
+
+      it 'redirects to the lesson edit page if specified' do
+        post :create, params: { course: valid_attributes, commit: 'Save & Edit Lessons' }
+        expect(response).to have_http_status(:redirect)
         expect(response).to redirect_to(new_admin_course_lesson_path(Course.find_by(title: valid_attributes[:title])))
       end
 
@@ -112,15 +118,9 @@ describe Admin::CoursesController do
         expect(response).to render_template('new')
       end
 
-      it 'saves course as draft if committed with draft' do
-        expect do
-          post :create, params: { course: valid_attributes, commit: 'Save as Draft' }
-        end.to change { Course.where(pub_status: 'D').count }.by(1)
-      end
-
       it 'publishes course if committed with publish' do
         expect do
-          post :create, params: { course: valid_attributes, commit: 'Publish Course' }
+          post :create, params: { course: valid_attributes.merge(pub_status: 'P') }
         end.to change { Course.where(pub_status: 'P').count }.by(1)
       end
     end

--- a/spec/controllers/admin/courses_controller/update_spec.rb
+++ b/spec/controllers/admin/courses_controller/update_spec.rb
@@ -28,35 +28,35 @@ describe Admin::CoursesController do
         update_params.merge(course_topics_attributes: [{ topic_attributes: { title: 'Another new topic' } }])
       end
 
-      let(:publish_request) do
-        patch :update, params: { id: pla_course.to_param, course: update_params, commit: 'Publish Course' }
+      let(:save_request) do
+        patch :update, params: { id: pla_course.to_param, course: update_params, commit: 'Save Course' }
       end
 
       it 'redirects to edit path' do
-        publish_request
+        save_request
         expect(response).to redirect_to(edit_admin_course_path(pla_course.reload))
       end
 
       it 'updates title' do
         expect do
-          publish_request
+          save_request
         end.to change { pla_course.reload.title }.from('PLA Course').to('Updated Title')
       end
 
       it 'updates access level' do
         expect do
-          publish_request
+          save_request
         end.to change { pla_course.reload.access_level }.from('everyone').to('authenticated_users')
       end
 
       it 'updates category' do
         expect do
-          publish_request
+          save_request
         end.to change { pla_course.reload.category }.from(pla_category1).to(pla_category2)
       end
 
       it 'displays appropriate notice for successful course update' do
-        publish_request
+        save_request
         expect(flash[:notice]).to eq('Course was successfully updated.')
       end
 
@@ -74,7 +74,7 @@ describe Admin::CoursesController do
       describe 'propagation' do
         it 'propagates title to child courses' do
           expect do
-            publish_request
+            save_request
           end.to change { child_course.reload.title }.to('Updated Title')
         end
 
@@ -86,13 +86,13 @@ describe Admin::CoursesController do
 
         it 'does not assign course to main site category' do
           expect do
-            publish_request
+            save_request
           end.to_not(change { child_course.reload.category })
         end
 
         it 'does not change child course access level' do
           expect do
-            publish_request
+            save_request
           end.to_not(change { child_course.reload.access_level })
         end
 
@@ -152,35 +152,29 @@ describe Admin::CoursesController do
         sign_in admin
       end
 
-      describe 'publish an imported course' do
+      describe 'save an imported course' do
         let(:new_category) { FactoryBot.create(:category, organization: org) }
-
-        it 'should change the publication status' do
-          expect do
-            patch :update, params: { id: child_course.to_param, course: child_course.attributes, commit: 'Publish' }
-          end.to change { child_course.reload.pub_status }.from('D').to('P')
-        end
 
         it 'should not change title, if new title is given' do
           expect do
-            patch :update, params: { id: child_course.to_param, course: { title: 'New Title' }, commit: 'Publish' }
+            patch :update, params: { id: child_course.to_param, course: { title: 'New Title' }, commit: 'Save Course' }
           end.to_not(change { child_course.reload.title })
         end
 
-        it 'should redirect to admin dashboard' do
-          patch :update, params: { id: child_course.to_param, course: child_course.attributes, commit: 'Publish' }
-          expect(response).to redirect_to(admin_dashboard_index_path)
+        it 'should redirect to course edit page' do
+          patch :update, params: { id: child_course.to_param, course: child_course.attributes, commit: 'Save Course' }
+          expect(response).to redirect_to(edit_admin_course_path(child_course))
         end
 
         it 'should change the course category, if given' do
           expect do
-            patch :update, params: { id: child_course.to_param, course: { category_id: new_category.id }, commit: 'Publish' }
+            patch :update, params: { id: child_course.to_param, course: { category_id: new_category.id }, commit: 'Save Course' }
           end.to change { child_course.reload.category }.to(new_category)
         end
 
         it 'should change the course access level, if given' do
           expect do
-            patch :update, params: { id: child_course.to_param, course: { access_level: 'authenticated_users' }, commit: 'Publish' }
+            patch :update, params: { id: child_course.to_param, course: { access_level: 'authenticated_users' }, commit: 'Save Course' }
           end.to change { child_course.reload.access_level }.from('everyone').to('authenticated_users')
         end
       end

--- a/spec/features/admin/edit_course_spec.rb
+++ b/spec/features/admin/edit_course_spec.rb
@@ -58,10 +58,7 @@ feature 'Admin user updates course' do
       expect(page).to have_content('Text copies of the course to allow users to download content and view offline or follow along with the online course.')
       expect(page).to have_content('Supplemental materials for further learning. These files are available to users after completing the course.')
 
-      expect(page).to_not have_button('Publish Course')
-      expect(page).to_not have_button('Edit Lessons')
-
-      expect(page).to have_button('Publish')
+      expect(page).to have_button('Save Course')
       expect(page).to have_content('If you wish to edit details of this course and use the PLA-created Storyline files, please contact a PLA Administrator.')
       expect(page).to have_link('contact a PLA Administrator')
     end
@@ -70,11 +67,10 @@ feature 'Admin user updates course' do
       visit edit_admin_course_path(subsite_course)
       within(:css, 'main') do
         select('Authenticated Users', from: 'course_access_level')
-        click_button 'Publish'
+        click_button 'Save Course'
       end
-      expect(current_path).to eq(admin_dashboard_index_path)
-      expect(page).to have_content('Course successfully published!')
-      visit(edit_admin_course_path(subsite_course))
+      expect(current_path).to eq(edit_admin_course_path(subsite_course))
+      expect(page).to have_content('Course was successfully updated.')
       expect(page).to have_select('course_access_level', selected: 'Authenticated Users')
     end
 
@@ -82,10 +78,8 @@ feature 'Admin user updates course' do
       visit edit_admin_course_path(subsite_course)
       within(:css, 'main') do
         select(category.name, from: 'course_category_id')
-        click_button 'Publish'
+        click_button 'Save Course'
       end
-      expect(current_path).to eq(admin_dashboard_index_path)
-      visit(edit_admin_course_path(subsite_course))
       expect(page).to have_select('course_category_id', selected: category.name)
     end
 
@@ -94,7 +88,7 @@ feature 'Admin user updates course' do
       within(:css, 'main') do
         select('Create new category', from: 'course_category_id')
         fill_in :course_category_attributes_name, with: category.name
-        click_button 'Publish'
+        click_button 'Save Course'
       end
       expect(current_path).to eq(admin_course_path(subsite_course))
       expect(page).to have_content('Category Name is already in use by your organization.')
@@ -108,10 +102,8 @@ feature 'Admin user updates course' do
       within(:css, 'main') do
         select('Create new category', from: 'course_category_id')
         fill_in :course_category_attributes_name, with: "#{category.name}_#{new_word}"
-        click_button 'Publish'
+        click_button 'Save Course'
       end
-      expect(current_path).to eq(admin_dashboard_index_path)
-      visit(edit_admin_course_path(subsite_course))
       expect(page).to have_select('course_category_id', selected: "#{category.name}_#{new_word}")
     end
 
@@ -132,20 +124,14 @@ feature 'Admin user updates course' do
       visit edit_admin_course_path(custom_subsite_course)
       attach_file 'Text Copies of Course', Rails.root.join('spec', 'fixtures', 'BasicSearch1.zip')
       attach_file 'Additional Resources', Rails.root.join('spec', 'fixtures', 'BasicSearch1.zip')
-      click_button 'Publish Course'
+      click_button 'Save Course'
       expect(page).to have_content('Attachments document is invalid. Only PDF, Word, PowerPoint, or Excel files are allowed.', count: 1)
     end
 
     scenario 'can edit course title' do
       visit edit_admin_course_path(custom_subsite_course)
       fill_in 'Title', with: 'New Course Title'
-      click_button 'Save as Draft'
-      expect(page).to have_content('Course saved as draft.')
-      visit admin_courses_path
-      expect(page).to have_select("course_#{custom_subsite_course.id}", selected: 'Draft')
-      click_link 'New Course Title'
-      expect(page).to have_content('Edit This Course')
-      click_button 'Publish Course'
+      click_button 'Save Course'
       expect(page).to have_content('Course was successfully updated.')
       expect(current_path).to eq(edit_admin_course_path(custom_subsite_course.reload))
       expect(page).to have_field('Title', with: 'New Course Title')

--- a/spec/features/admin/new_course_spec.rb
+++ b/spec/features/admin/new_course_spec.rb
@@ -33,9 +33,22 @@ feature 'Admin user creates new course and lesson' do
     visit new_admin_course_path
   end
 
+  scenario 'toggles course publication status' do
+    fill_basic_course_info
+    expect(page).to have_select('Publication Status', selected: 'Draft')
+    select('Published', from: 'Publication Status')
+    click_button 'Save Course'
+    expect(page).to have_content('Course was successfully created.')
+    expect(page).to have_select('Publication Status', selected: 'Published')
+    select('Archived', from: 'Publication Status')
+    click_button 'Save Course'
+    visit admin_courses_path
+    expect(page).to_not have_content('New Course Title')
+  end
+
   scenario 'assigns topics' do
     fill_basic_course_info
-    click_button 'Publish Course'
+    click_button 'Save Course'
     expect(page).to have_field('Topic A', checked: true)
     expect(page).to have_field('Some New Topic', checked: true)
   end
@@ -44,7 +57,7 @@ feature 'Admin user creates new course and lesson' do
     fill_basic_course_info
     select('Create new category', from: 'course_category_id')
     fill_in :course_category_attributes_name, with: new_category_name
-    click_button 'Publish Course'
+    click_button 'Save Course'
     expect(page).to have_content('Course was successfully created.')
     expect(current_path).to eq(edit_admin_course_path(Course.last))
     expect(page).to have_select('course_category_id', selected: Course.last.category.name)
@@ -53,7 +66,7 @@ feature 'Admin user creates new course and lesson' do
   scenario 'creates new course with existing category' do
     fill_basic_course_info
     select(category.name, from: 'course_category_id')
-    click_button 'Publish Course'
+    click_button 'Save Course'
     expect(page).to have_content('Course was successfully created.')
     expect(current_path).to eq(edit_admin_course_path(Course.last))
     expect(page).to have_select('course_category_id', selected: category.name)
@@ -66,7 +79,7 @@ feature 'Admin user creates new course and lesson' do
   scenario 'attempts to create duplicate category' do
     select('Create new category', from: 'course_category_id')
     fill_in :course_category_attributes_name, with: category.name
-    click_button 'Publish Course'
+    click_button 'Save Course'
     expect(page).to have_content('Category Name is already in use by your organization.')
     expect(page).to have_select('course_category_id', selected: 'Create new category')
     expect(page).to have_selector(:css, ".field_with_errors #course_category_attributes_name[value='#{category.name}']")
@@ -76,12 +89,12 @@ feature 'Admin user creates new course and lesson' do
     fill_basic_course_info
     attach_file 'Text Copies of Course', Rails.root.join('spec', 'fixtures', 'BasicSearch1.zip')
     attach_file 'Additional Resources', Rails.root.join('spec', 'fixtures', 'BasicSearch1.zip')
-    click_button 'Publish Course'
+    click_button 'Save Course'
     expect(page).to have_content('Attachments document is invalid. Only PDF, Word, PowerPoint, or Excel files are allowed.', count: 1)
 
     attach_file 'Text Copies of Course', Rails.root.join('spec', 'fixtures', 'Why_Use_a_Computer_1.pdf')
     attach_file 'Additional Resources', Rails.root.join('spec', 'fixtures', 'Why_Use_a_Computer_Worksheet.pdf')
-    click_button 'Publish Course'
+    click_button 'Save Course'
     expect(page).to have_content('Course was successfully created.')
     expect(page).to have_content('Why_Use_a_Computer_1.pdf')
     expect(page).to have_content('Why_Use_a_Computer_Worksheet.pdf')


### PR DESCRIPTION
Using different buttons for different publication status actions led to confusing UX. Using the publication status dropdown clears up some of that confusion.