### PR TITLE
Require program location name

### DIFF
--- a/app/views/admin/program_locations/create.js.erb
+++ b/app/views/admin/program_locations/create.js.erb
@@ -1,2 +1,4 @@
-$("#program_location_rows").append("<%= escape_javascript(render(partial: 'location_row', locals: { program_location: @program_location })) %>");
-$("#program_location_location_name").val('');
+<% if @program_location.valid? %>
+  $("#program_location_rows").append("<%= escape_javascript(render(partial: 'location_row', locals: { program_location: @program_location })) %>");
+  $("#program_location_location_name").val('');
+<% end %>

--- a/app/views/admin/programs/_program_locations_form.html.erb
+++ b/app/views/admin/programs/_program_locations_form.html.erb
@@ -2,7 +2,7 @@
 <div class='form-row'>
   <fieldset>
     <div class='inline-form'>
-      <%= f.text_field :location_name %>
+      <%= f.text_field :location_name, required: true %>
       <%= f.submit "Add", id: "addLocation" %>
       <%= f.hidden_field :program_id, :value => @program.id %>
     </div>


### PR DESCRIPTION
ProgramLocations aren't valid without a name. Prior to this change, the `create` action would just fail with a 500 if you tried to add a Program Location without a name.

This makes the name required and doesn't attempt to render a new program location row if the record is invalid.