### PR TITLE
Only list active schools in registration dropdown

### DIFF
--- a/app/controllers/ajax/schools_controller.rb
+++ b/app/controllers/ajax/schools_controller.rb
@@ -5,7 +5,7 @@ module Ajax
     skip_after_action :verify_policy_scoped, only: :index
 
     def index
-      @schools = current_organization.schools.where(school_type: params[:school_type])
+      @schools = current_organization.schools.where(school_type: params[:school_type]).enabled
       render json: @schools
     end
 

--- a/spec/controllers/ajax/schools_controller_spec.rb
+++ b/spec/controllers/ajax/schools_controller_spec.rb
@@ -11,21 +11,26 @@ describe Ajax::SchoolsController do
     @middle_school = create(:school, school_type: :middle_school, organization: organization)
     @high_school = create(:school, school_type: :high_school, organization: organization)
 
+    create(:school, school_type: :elementary, organization: organization, enabled: false)
+    create(:school, school_type: :elementary, organization: organization, enabled: false)
+    create(:school, school_type: :middle_school, organization: organization, enabled: false)
+    create(:school, school_type: :high_school, organization: organization, enabled: false)
+
     @request.host = "#{organization.subdomain}.test.host"
   end
 
   describe 'GET #index' do
-    it 'returns elementary schools' do
+    it 'returns active elementary schools' do
       get :index, params: { school_type: 'elementary' }, format: :js
       expect(JSON.parse(response.body)).to contain_exactly(JSON.parse(@elementary_school1.to_json), JSON.parse(@elementary_school2.to_json))
     end
 
-    it 'returns middle schools' do
+    it 'returns active middle schools' do
       get :index, params: { school_type: 'middle_school' }, format: :js
       expect(response.body).to eq([@middle_school].to_json)
     end
 
-    it 'returns high schools' do
+    it 'returns active high schools' do
       get :index, params: { school_type: 'high_school' }, format: :js
       expect(response.body).to eq([@high_school].to_json)
     end


### PR DESCRIPTION
Schools can be "disabled" in an admin view, so only the "enabled" schools should show up in the registration list.