### PR TITLE
Make Student ID required in the UI for students

### DIFF
--- a/app/assets/javascripts/registrations/schools_form.js
+++ b/app/assets/javascripts/registrations/schools_form.js
@@ -1,15 +1,12 @@
 var schoolsForm = (function () {
   function showForm() {
     $("#school_fields").show();
-  }
-
-  function resetForm() {
-    // Clear options
-    $("#school_fields hideUntilActive").hide();
+    $("#user_acting_as").trigger("change");
   }
 
   function hideForm() {
     $("#school_fields").hide();
+    $("#user_student_id").prop("required", false);
   }
 
   function loadSchoolsByType(schoolType) {
@@ -25,7 +22,7 @@ var schoolsForm = (function () {
 
   function showStudentFields() {
     $("#student-only").show();
-    $("#user_student_id").attr("placeholder", "Student ID #");
+    $("#user_student_id").attr("placeholder", "Student ID # *");
   }
 
   function hideStudentFields() {
@@ -33,13 +30,22 @@ var schoolsForm = (function () {
     $("#user_student_id").attr("placeholder", "Students' ID #s");
   }
 
+  function makeStudentIdRequired() {
+    $("#user_student_id").prop("required", true);
+  }
+
+  function makeStudentIdOptional() {
+    $("#user_student_id").prop("required", false);
+  }
+
   return {
     showForm: showForm,
-    resetForm: resetForm,
     hideForm: hideForm,
     loadSchoolsByType: loadSchoolsByType,
     showStudentFields: showStudentFields,
     hideStudentFields: hideStudentFields,
+    makeStudentIdRequired: makeStudentIdRequired,
+    makeStudentIdOptional: makeStudentIdOptional,
   };
 })();
 
@@ -49,8 +55,10 @@ $(document).ready(function () {
 
     if (newRole == "Student") {
       schoolsForm.showStudentFields();
+      schoolsForm.makeStudentIdRequired();
     } else {
       schoolsForm.hideStudentFields();
+      schoolsForm.makeStudentIdOptional();
     }
   });
 

--- a/spec/features/user/school_registration_spec.rb
+++ b/spec/features/user/school_registration_spec.rb
@@ -29,7 +29,7 @@ feature 'user signs up for school program' do
     find('#user_profile_attributes_last_name').set(last_name)
     find('#user_profile_attributes_zip_code').set(zip_code)
 
-    expect(page).to have_content "Library Card Number (Optional)"
+    expect(page).to have_content 'Library Card Number (Optional)'
 
     fill_in 'user_password_confirmation', with: password
 


### PR DESCRIPTION
"Require" student IDs for users registering as Students.

This is purely a UI change meant to encourage Students to register with a Student ID. We don't have any existing or planned features that rely on Student IDs being present in the database (the format isn't even validated).