### PR TITLE
Send requested format to rollbar on unknown format error

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -4,6 +4,8 @@ class LessonsController < ApplicationController
   before_action :auth_subsites
   before_action :set_course
 
+  rescue_from ActionController::UnknownFormat, with: :report_unknown_format
+
   def show
     @lesson = @course.lessons.friendly.find(params[:id])
     @preview = params[:preview]
@@ -63,9 +65,16 @@ class LessonsController < ApplicationController
         end
       end
     end
+
   end
 
   private
+
+  def report_unknown_format(exception)
+    request_format = request.format
+
+    Rollbar.error(exception, request_format: request_format)
+  end
 
   def set_course
     @course = Course.friendly.find(params[:course_id])

--- a/spec/controllers/lessons_controller_spec.rb
+++ b/spec/controllers/lessons_controller_spec.rb
@@ -115,6 +115,11 @@ describe LessonsController do
       end.to_not change(LessonCompletion, :count)
     end
 
+    it 'logs info to rollbar on unknown format' do
+      expect(Rollbar).to receive(:error).once
+      post :complete, params: { course_id: course.to_param, lesson_id: lesson1.to_param }, format: :foobar
+    end
+
     context 'preview' do
       let(:pla) { FactoryBot.create(:default_organization) }
       let(:pla_course) { FactoryBot.create(:course_with_lessons, organization: pla) }


### PR DESCRIPTION
We're getting `ActionController::UnknownFormat` errors, but it looks like the requests have the correct headers for a json response. I can't recreate the issue and I'm trying to figure out what Rails thinks the requested format is.