### PR TITLE
Use sendgrid api key instead of username and password

### DIFF
--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -1,15 +1,14 @@
 # Initialize ActionMailer settings for sendgrid
 
-login = Rails.application.secrets.sendgrid_login
-password = Rails.application.secrets.sendgrid_password
+api_key = Rails.application.secrets.sendgrid_api_key
 domain = Rails.application.secrets.sendgrid_domain || "chipublib.digitallearn.org"
 
 if login.nil? and password.nil?
   abort('Please ensure the sendgrid_login and sendgrid_password are defined in secrets.yml')
 else
   ActionMailer::Base.smtp_settings = {
-    :user_name => login,
-    :password => password,
+    :user_name => 'apikey',
+    :password => api_key,
     :domain => domain,
     :address => 'smtp.sendgrid.net',
     :port => 587,

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,7 +1,6 @@
 default: &default
-  sendgrid_login:
-  sendgrid_password:
-  sendgrid_domain:
+  sendgrid_api_key: ""
+  sendgrid_domain: ""
   notification_default_from: "no-reply@example.com"
   rollbar_api_key: ""
   recaptcha_site_key: ""


### PR DESCRIPTION
SendGrid now recommends using API Keys instead of username and password authentication.