### PR TITLE
Actually import courses when creating new subsites

### DIFF
--- a/db/data/20210209193144_create_mdpls_subsite.rb
+++ b/db/data/20210209193144_create_mdpls_subsite.rb
@@ -26,7 +26,7 @@ class CreateMdplsSubsite < ActiveRecord::Migration[5.2]
 
     # Import all subsite courses
     Course.pla.where(pub_status: 'P').each do |course|
-      CourseImportService.new(organization: subsite, course_id: course.id)
+      CourseImportService.new(organization: subsite, course_id: course.id).import!
     end
   end
 

--- a/docs/adding_a_subsite.md
+++ b/docs/adding_a_subsite.md
@@ -94,7 +94,7 @@ To deploy a new subsite, use a [data migration](https://github.com/ilyakatz/data
 
       # Import all subsite courses
       Course.pla.where(pub_status: 'P').each do |course|
-        CourseImportService.new(organization: subsite, course_id: course.id)
+        CourseImportService.new(organization: subsite, course_id: course.id).import!
       end
     end
 


### PR DESCRIPTION
The new subsite migration was documented without `.import!` on the import service call. All published PLA courses should be added to new subsites as drafts.