### PR TITLE
Define mail interceptor natively without gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,7 +132,3 @@ group :test do
   gem 'webdrivers'
   gem 'webmock'
 end
-
-group :development, :staging do
-  gem 'mail_interceptor'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,8 +189,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mail_interceptor (0.0.7)
-      activesupport
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
@@ -461,7 +459,6 @@ DEPENDENCIES
   letter_opener
   listen
   local_time (>= 2.0)
-  mail_interceptor
   mocha
   nilify_blanks
   paperclip

--- a/config/initializers/mail_interceptor.rb
+++ b/config/initializers/mail_interceptor.rb
@@ -1,9 +1,16 @@
-unless Rails.env.test? || Rails.env.production?
-  options = { forward_emails_to:
-    ["joe+stagingdl@ckdtech.co",
-      "susie+stagingdl@ckdtech.co",
-      "ming+stagingdl@ckdtech.co",
-      "tom+stagingdl@ckdtech.co"] }
-  interceptor = MailInterceptor::Interceptor.new(options)
-  ActionMailer::Base.register_interceptor(interceptor)
+if Rails.env.staging?
+  class MailInterceptor
+    def self.delivering_email(message)
+      allowed_domains = /@ckdtech.co$|@commercekitchen.com$|@annealinc.com$/i
+      recipients = Array(message.to).select { |recipient| (recipient =~ allowed_domains).present? }
+
+      # If filtered recipients doesn't include any acceptable
+      # recipient, auto populate with some employees
+      recipients = %w[tom@ckdtech.co alex@ckdtech.co] if recipients.empty?
+
+      message.to = recipients
+    end
+  end
+
+  ActionMailer::Base.register_interceptor(MailInterceptor)
 end


### PR DESCRIPTION
Define mail interceptor with PORO instead of gem

Whitelist all @ckdtech.co, @commercekitchen.com and @annealinc.com addresses for Staging

Forward intercepted emails to updated project team.