### PR TITLE
Unescape html in banner translation

### DIFF
--- a/app/views/shared/_logo_banner.html.erb
+++ b/app/views/shared/_logo_banner.html.erb
@@ -3,5 +3,5 @@
     <%= t('logged_in_user.hi') %> <%=current_user.first_name%><%= "(ADMIN)" if current_user.admin? %>!
     <br>
   <% end %>
-  <%= raw i18n_with_default("home.#{current_organization.subdomain}.custom_banner_greeting") %>
+  <%= raw(CGI.unescape_html(i18n_with_default("home.#{current_organization.subdomain}.custom_banner_greeting"))) %>
 </h1>


### PR DESCRIPTION
There was a bug on Production where a custom banner greeting wouldn't display.

It was not a problem in other environments. I'm not sure exactly why there was a discrepancy, but it might have had to do with a specific type of single quote.

After some experimentation, I found that unescaping the custom translation before attempting to render it as HTML resolved the issue.