### PR TITLE
Handle missing files in s3 uploader

### DIFF
--- a/lib/s3_uploader.rb
+++ b/lib/s3_uploader.rb
@@ -9,6 +9,11 @@ class S3Uploader
     filename = record.send("#{attachment_name}_file_name")
     return unless filename.present?
 
+    if !File.exist?(record.send(attachment_name).path(style))
+      puts "File #{filename} doesn't exist for #{record.class.name} #{record.id}"
+      return
+    end
+
     s3_path = "#{record.class.name.downcase.pluralize}/#{attachment_name.pluralize}/#{record.id}"
     s3_path += "/#{style}" if style.present?
     s3_path += "/#{filename}"


### PR DESCRIPTION
Some of the uploaded attachment files have been incompletely deleted - the file path references still exist in the database, but the files are no longer on the server.