### PR TITLE
Only display sign in prompt if org has visible private courses

### DIFF
--- a/app/views/shared/_course_intro_text.html.erb
+++ b/app/views/shared/_course_intro_text.html.erb
@@ -27,7 +27,7 @@
     <% end %>
   <% end %>
 
-  <% if current_organization.courses.authenticated_users.exists? %>
+  <% if current_organization.courses.visible_to_users.authenticated_users.exists? %>
     <p class="center">
       <%= t('home.more_courses') %>
       <%= link_to t('home.here'), login_path, class: "inline_link" %>

--- a/spec/features/anonymous_user/home_page_spec.rb
+++ b/spec/features/anonymous_user/home_page_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'feature_helper'
+
+feature 'User views home page' do
+  let(:org) { FactoryBot.create(:default_organization) }
+  let(:more_courses_message) { 'More courses are available if you' }
+
+  context 'organization has no private courses' do
+    let!(:course) do
+      FactoryBot.create(:course, organization: org, access_level: :everyone)
+    end
+
+    scenario 'should not see more courses message' do
+      visit root_path
+      expect(page).not_to have_content(more_courses_message)
+    end
+  end
+
+  context 'organization has private courses' do
+    let!(:private_course) do
+      FactoryBot.create(:course,
+                        organization: org,
+                        access_level: :authenticated_users)
+    end
+
+    scenario 'should see more courses link for published private course' do
+      visit root_path
+      expect(page).to have_content(more_courses_message)
+    end
+
+    scenario 'should see more courses link for coming soon private course' do
+      private_course.update(pub_status: 'C')
+      visit root_path
+      expect(page).to have_content(more_courses_message)
+    end
+
+    scenario 'should not see the more courses link for draft private course' do
+      private_course.update(pub_status: 'D')
+      visit root_path
+      expect(page).not_to have_content(more_courses_message)
+    end
+
+    scenario 'should not see the more courses link for archived private course' do
+      private_course.update(pub_status: 'A')
+      visit root_path
+      expect(page).not_to have_content(more_courses_message)
+    end
+  end
+end

--- a/spec/features/user/user_can_view_their_courses_spec.rb
+++ b/spec/features/user/user_can_view_their_courses_spec.rb
@@ -47,6 +47,11 @@ feature 'User is able to view the courses in their plan' do
       expect(page).to have_content('Find new courses when you retake the quiz')
       expect(page).to have_link('Retake the Quiz')
     end
+
+    scenario 'should not see the more courses blurb' do
+      visit my_courses_path
+      expect(page).not_to have_content('More courses are available if you sign up')
+    end
   end
 
   context 'npl user' do


### PR DESCRIPTION
Users should see a prompt to sign in to see more courses if their organization has _visible_ private courses. Archived or draft private courses shouldn't cause this link to show.