### PR TITLE
Add anchor IDs to course category headers

### DIFF
--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -64,4 +64,9 @@ module CoursesHelper
 
     link_to t('course_page.start_course').to_s, lesson_path, class: 'btn button-color', data: { cpl_ga_event: 'on', cpl_ga_value: 'user-start-course' }
   end
+
+  def category_anchor(category_name)
+    anchor_id = category_name.downcase.parameterize
+    content_tag(:h3, category_name, id: anchor_id)
+  end
 end

--- a/app/views/shared/courses/_listing.html.erb
+++ b/app/views/shared/courses/_listing.html.erb
@@ -1,5 +1,5 @@
 <% categorized_courses(@courses).each do |category_name, courses| %>
-  <h3><%= category_name %></h3>
+  <%= category_anchor(category_name) %>
   <div class="flex-list">
     <% courses.each do |course| %>
       <% if course.published? %>

--- a/spec/helpers/courses_helper_spec.rb
+++ b/spec/helpers/courses_helper_spec.rb
@@ -123,4 +123,14 @@ describe CoursesHelper do
       expect(helper.start_or_resume_course_link(course, true)).to include(expected_path)
     end
   end
+
+  describe '#category_anchor' do
+    let(:category_name) { "Test Course Category" }
+    let(:subject) { helper.category_anchor(category_name) }
+
+    it 'returns expected tag' do
+      expected_tag = '<h3 id="test-course-category">Test Course Category</h3>'
+      expect(subject).to match(expected_tag)
+    end
+  end
 end


### PR DESCRIPTION
Add IDs to course category headers so they can be linked as anchors.