### PR TITLE
Upload storyline zip files as private

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -82,6 +82,7 @@ Rails.application.configure do
     storage: :s3,
     path: 'storylines/:id/:basename.:extension',
     bucket: config.zip_bucket_name,
-    s3_region: config.s3_region
+    s3_region: config.s3_region,
+    s3_permissions: 'private'
   }
 end


### PR DESCRIPTION
Use private object acl for s3 storyline zip file uploads.