### PR TITLE
Remove s3 delete from application policy

### DIFF
--- a/ops/modules/application/iam_profile.tf
+++ b/ops/modules/application/iam_profile.tf
@@ -52,7 +52,14 @@ data "aws_iam_policy_document" "instance_policy" {
     sid = "AllObjectActions"
 
     actions = [
-      "s3:*Object*"
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:GetObjectAcl",
+      "s3:PutObjectAcl",
+      "s3:ListBucket",
+      "s3:GetBucketAcl",
+      "s3:PutBucketAcl",
+      "s3:GetBucketLocation"
     ]
 
     resources = formatlist("%s/*", var.s3_bucket_arns)


### PR DESCRIPTION
We don't want the application to be able to remove storyline .zip files from s3.