### PR TITLE
Send application logs to stdout

### DIFF
--- a/ops/modules/application/task_definition.tf
+++ b/ops/modules/application/task_definition.tf
@@ -45,8 +45,12 @@ resource "aws_ecs_task_definition" "app_service" {
           value = "${var.environment_name}"
         },
         {
-          name  = "RAILS_MAX_THREADS"
+          name  = "RAILS_MAX_THREADS",
           value = "5"
+        },
+        {
+          name  = "RAILS_LOG_TO_STDOUT",
+          value = true
         }
       ],
       logConfiguration = {


### PR DESCRIPTION
Set environment variable to log application logs to STDOUT so they make it to the container and beyond.