### PR TITLE
Trim whitespace before normalizing footer links

### DIFF
--- a/app/models/footer_link.rb
+++ b/app/models/footer_link.rb
@@ -12,6 +12,7 @@ class FooterLink < ApplicationRecord
   private
 
   def normalize_url
+    url.strip!
     uri = URI.parse(url)
     
     if uri.scheme.nil? && uri.host.nil?

--- a/spec/models/footer_link_spec.rb
+++ b/spec/models/footer_link_spec.rb
@@ -40,4 +40,10 @@ RSpec.describe FooterLink, type: :model do
     link.save
     expect(link.reload.url).to eq('http://www.example.com')
   end
+
+  it 'handles whitespace' do
+    link.url = ' https://www.example.com/'
+    link.save
+    expect(link.reload.url).to eq('https://www.example.com/')
+  end
 end


### PR DESCRIPTION
Avoid errors when creating footer links with extra whitespace