### PR TITLE
Use course-specific survey URL if present

### DIFF
--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -123,7 +123,7 @@
     <%= f.label :survey_url do %>
       Course Completion Survey URL
     <% end %>
-    <p><i>This url will open in a new tab automatically on course completion.</i></p>
+    <p><i>This url will be used instead of the Organization custom survey URL on the Course Completion page</i></p>
     <%= f.text_field :survey_url %>
   </fieldset>
 

--- a/app/views/course_completions/_user_survey.html.erb
+++ b/app/views/course_completions/_user_survey.html.erb
@@ -1,5 +1,6 @@
-<% if current_organization.user_survey_enabled? %>
-  <%= link_to(current_organization.survey_url(I18n.locale), target: '_blank') do %>
+<% @survey_url = @course.survey_url || current_organization.survey_url(I18n.locale) %>
+<% if @survey_url.present? %>
+  <%= link_to(@survey_url, target: '_blank') do %>
     <%= button_tag(type: 'button', class: "congrats-button button-color small") do %>
       <%= i18n_with_default("course_completion_page.#{current_organization.subdomain}.user_survey_button_text") %>
     <% end %>

--- a/app/views/course_completions/show.html.erb
+++ b/app/views/course_completions/show.html.erb
@@ -50,10 +50,3 @@
   </div>
   <%= link_to "#{t('course_completion_page.restart_this_course')}", course_path(@course), class: "white" %>
 </div>
-
-<% # Open course completion survey url in new tab & focus %>
-<% if @course.survey_url.present? %>
-  <%= javascript_tag do %>
-    window.open('<%= @course.survey_url %>', '_blank').focus();
-  <% end %>
-<% end %>


### PR DESCRIPTION
Replaces the Organization-wide survey link with a course-specific survey link, if present.

Removes the automatic survey link opening feature, which was broken.