### PR TITLE
Required survey bugfix and course form rearrangement

### DIFF
--- a/app/assets/stylesheets/components/_course_form.scss
+++ b/app/assets/stylesheets/components/_course_form.scss
@@ -42,6 +42,28 @@
       "course_level ."
       "seo_title seo_title"
       "seo_meta seo_meta";
+
+    &.custom-topics {
+      grid-template-areas:
+        "errors errors"
+        "categories access_level"
+        "resources resources"
+        "links links"
+        "additional_content additional_content"
+        "pub_status ."
+        "survey_url ."
+        "topics ."
+        "actions actions"
+        "title title"
+        "author author"
+        "summary summary"
+        "description description"
+        "text_copies text_copies"
+        "language format"
+        "course_level ."
+        "seo_title seo_title"
+        "seo_meta seo_meta";
+    }
   }
 
   .error_explanation {

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -30,6 +30,7 @@ module Admin
     def edit
       authorize @course
       @imported_course = @course.imported_course?
+      @custom_topics = @course.organization.custom_topics?
     end
 
     def create

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -12,6 +12,11 @@ class LessonsController < ApplicationController
 
     authorize_lesson
 
+    if current_user && current_organization.survey_required? && current_user.quiz_responses_object.blank?
+      flash[:notice] = 'Please complete the Course Recommendation Survey before accessing courses.'
+      redirect_to new_course_recommendation_survey_path and return
+    end
+
     @next_lesson = @course.lesson_after(@lesson)
 
     if current_user

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for([:admin, @course], html: { multipart: true, class: "course-form #{'restricted' if @imported_course}" } ) do |f| %>
+<%= form_for([:admin, @course], html: { multipart: true, class: "course-form #{'restricted' if @imported_course} #{'custom-topics' if @imported_course && @custom_topics}" } ) do |f| %>
   <% if @course.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@course.errors.count, "error") %> prohibited this course from being saved:</h2>

--- a/app/views/admin/courses/forms/_topics.html.erb
+++ b/app/views/admin/courses/forms/_topics.html.erb
@@ -1,5 +1,5 @@
 <fieldset class='topics'>
-  <% topics_allowed = current_organization.custom_topics? || !@imported_course %>
+  <% topics_allowed = !@imported_course || @custom_topics %>
   <%= f.label :topic_ids, class: "#{'disabled' if !topics_allowed}" do %>
     Course Topics<span class="required"></span>
   <% end %>

--- a/spec/features/user/user_completes_course_spec.rb
+++ b/spec/features/user/user_completes_course_spec.rb
@@ -105,10 +105,11 @@ feature 'User visits course complete page' do
       expect(page).to have_content('Post-Course completion notes...')
     end
 
-    scenario 'sees survey url in a new tab if configured', js: true do
+    scenario 'opens custom survey url in a new tab if configured', js: true do
       survey_url = 'https://survey.example.com'
       course.update(survey_url: survey_url)
       visit course_completion_path(course)
+      click_link('We Need Your Help - Please Take a Quick Survey')
       expect(page.windows.length).to eq(2)
       new_tab = page.driver.browser.window_handles.last
       page.driver.browser.switch_to.window(new_tab)

--- a/spec/features/user/user_starts_course_spec.rb
+++ b/spec/features/user/user_starts_course_spec.rb
@@ -53,10 +53,27 @@ feature 'User visits course listing page' do
     end
 
     context 'on a login_required subdomain' do
+      let(:password) { 'asdfasdf'}
+      let(:user) { create(:user, password: password, organization: organization) }
+
       scenario 'can click to start a course and is required to sign in' do
         visit course_path(course1)
         click_link 'Start Course'
         expect(current_path).to eq(user_session_path)
+        expect(page).to have_content('You need to sign in or sign up before continuing.')
+        log_in_with(user.email, password)
+        expect(current_path).to eq(course_lesson_path(course1, course1.lessons.first))
+      end
+
+      scenario 'is prompted to complete survey after login if required' do
+        organization.update(survey_required: true)
+        visit course_path(course1)
+        click_link 'Start Course'
+        expect(current_path).to eq(user_session_path)
+        expect(page).to have_content('You need to sign in or sign up before continuing.')
+        log_in_with(user.email, password)
+        expect(current_path).to eq(new_course_recommendation_survey_path)
+        expect(page).to have_content('Please complete the Course Recommendation Survey before accessing courses.')
       end
     end
 


### PR DESCRIPTION
Require survey to view lessons if required by organization - courses are blocked at the lesson level when login is required and after login, users are redirected directly to the first lesson. If the organization requires the recommendation survey to view course content, we have to catch that requirement at the lesson level as well.

Also moves custom topics up with the other editable fields for imported courses when applicable.