### PR TITLE
Allow organizations to deidentify reports

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -18,6 +18,7 @@ class Organization < ApplicationRecord
     custom_recommendation_survey Boolean, default: false
     custom_topics                Boolean, default: false
     survey_required              Boolean, default: false
+    deidentify_reports           Boolean, default: false
   end
 
   # store_accessor :preferences, :footer_logo_file_name, :footer_logo_link, :footer_logo_content_type,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,7 @@ class User < ApplicationRecord
   nilify_blanks only: [:email]
 
   before_validation :set_password_from_pin, if: :library_card_login?
+  before_create :generate_uuid
 
   # Validate card number and pin for library card logins
   validates :library_card_number, uniqueness: { scope: :organization_id, if: :library_card_login? },
@@ -193,5 +194,9 @@ class User < ApplicationRecord
 
   def md5_digest(password, limit = 10)
     Digest::MD5.hexdigest(password).first(limit)
+  end
+
+  def generate_uuid
+    self.uuid = SecureRandom.uuid if self.uuid.blank?
   end
 end

--- a/app/services/completed_courses_exporter.rb
+++ b/app/services/completed_courses_exporter.rb
@@ -6,7 +6,7 @@ class CompletedCoursesExporter
 
   def initialize(org)
     @org = org
-    @primary_id_field = @org.authentication_key_field
+    @primary_id_field = @org.deidentify_reports ? :uuid : @org.authentication_key_field
   end
 
   def to_csv

--- a/app/services/no_courses_report_exporter.rb
+++ b/app/services/no_courses_report_exporter.rb
@@ -6,7 +6,7 @@ class NoCoursesReportExporter
 
   def initialize(org)
     @org = org
-    @primary_id_field = @org.authentication_key_field
+    @primary_id_field = @org.deidentify_reports ? :uuid : @org.authentication_key_field
   end
 
   def to_csv

--- a/app/services/registration_exporter.rb
+++ b/app/services/registration_exporter.rb
@@ -6,7 +6,7 @@ class RegistrationExporter
 
   def initialize(org)
     @org = org
-    @primary_id_field = @org.authentication_key_field
+    @primary_id_field = @org.deidentify_reports ? :uuid : @org.authentication_key_field
   end
 
   def to_csv

--- a/app/services/unfinished_courses_exporter.rb
+++ b/app/services/unfinished_courses_exporter.rb
@@ -6,7 +6,7 @@ class UnfinishedCoursesExporter
 
   def initialize(org)
     @org = org
-    @primary_id_field = @org.authentication_key_field
+    @primary_id_field = @org.deidentify_reports ? :uuid : @org.authentication_key_field
   end
 
   def to_csv

--- a/db/data/20231114045216_add_missing_uuids.rb
+++ b/db/data/20231114045216_add_missing_uuids.rb
@@ -1,0 +1,12 @@
+class AddMissingUuids < ActiveRecord::Migration[5.2]
+  def up
+    User.where(uuid: nil).each do |u|
+      u.uuid = SecureRandom.uuid
+      u.save(validate: false)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data/20231114052151_deidentify_getconnected_reports.rb
+++ b/db/data/20231114052151_deidentify_getconnected_reports.rb
@@ -1,0 +1,9 @@
+class DeidentifyGetconnectedReports < ActiveRecord::Migration[5.2]
+  def up
+    Organization.find_by(subdomain: 'getconnected').update(deidentify_reports: true)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,2 +1,2 @@
 # encoding: UTF-8
-DataMigrate::Data.define(version: 20231107060141)
+DataMigrate::Data.define(version: 20231114052151)

--- a/db/migrate/20231114043940_add_uuid_to_users.rb
+++ b/db/migrate/20231114043940_add_uuid_to_users.rb
@@ -1,0 +1,5 @@
+class AddUuidToUsers < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :users, :token, :uuid
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1045,7 +1045,7 @@ CREATE TABLE public.users (
     invited_by_type character varying,
     invited_by_id integer,
     invitations_count integer DEFAULT 0,
-    token character varying,
+    uuid character varying,
     organization_id integer,
     school_id integer,
     program_location_id integer,
@@ -1059,7 +1059,8 @@ CREATE TABLE public.users (
     encrypted_library_card_pin character varying,
     encrypted_library_card_pin_iv character varying,
     partner_id bigint,
-    phone_number character varying
+    phone_number character varying,
+    string uuid
 );
 
 
@@ -1991,6 +1992,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20221205023629'),
 ('20230116033009'),
 ('20231001021801'),
-('20231012203418');
+('20231012203418'),
+('20231114043940');
 
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,6 +8,10 @@ describe User do
   let(:course2) { FactoryBot.create(:course_with_lessons) }
   let(:course3) { FactoryBot.create(:course) }
 
+  it 'sets uuid for new user' do
+    expect(user.uuid).not_to be_nil
+  end
+
   context '#tracking_course?' do
     let!(:course_progress1) { FactoryBot.create(:course_progress, user: user, course: course1, tracked: true) }
     let!(:course_progress2) { FactoryBot.create(:course_progress, user: user, course: course2, tracked: false) }
@@ -19,7 +23,6 @@ describe User do
     it 'should return false for an un-tracked course' do
       expect(user.tracking_course?(course2.id)).to be false
     end
-
   end
 
   context '#completed_lesson_ids' do


### PR DESCRIPTION
Repurposes deprecated `User.token` field as a non-personally identifying id for admin reports.