### PR TITLE
Increase task resources

### DIFF
--- a/ops/modules/application/task_definition.tf
+++ b/ops/modules/application/task_definition.tf
@@ -1,9 +1,10 @@
 resource "aws_ecs_task_definition" "app_service" {
   family                   = "${var.project_name}-app-task-definition-${var.environment_name}"
   requires_compatibilities = ["EC2"]
-  memory                   = 512
-  cpu                      = 512
   network_mode             = "bridge"
+  memory                   = var.service_memory
+  cpu                      = var.service_cpu
+
 
   placement_constraints {
     type       = "memberOf"

--- a/ops/modules/application/variables.tf
+++ b/ops/modules/application/variables.tf
@@ -14,3 +14,5 @@ variable "lb_target_group_arn" {}
 variable "ssh_key_name" {}
 variable "desired_instance_count" {}
 variable "s3_bucket_arns" {}
+variable "service_memory" { default = 512 }
+variable "service_cpu" { default = 512 }

--- a/ops/modules/database/main.tf
+++ b/ops/modules/database/main.tf
@@ -9,7 +9,7 @@ resource "aws_db_subnet_group" "application" {
 
 resource "aws_db_instance" "app_db" {
   snapshot_identifier                   = var.db_snapshot_name
-  engine_version                        = "13.6"
+  engine_version                        = "13.14"
   allow_major_version_upgrade           = true
   instance_class                        = var.instance_size
   monitoring_interval                   = var.enable_monitoring ? var.monitoring_interval : 0

--- a/ops/modules/pipeline/main.tf
+++ b/ops/modules/pipeline/main.tf
@@ -32,7 +32,7 @@ locals {
 
 resource "aws_codebuild_project" "codebuild_project" {
   name          = "${var.project_name}-${var.environment_name}-codebuild-project"
-  build_timeout = 10
+  build_timeout = 20
   service_role  = aws_iam_role.codebuild_role.arn
 
   artifacts {

--- a/ops/modules/pipeline/main.tf
+++ b/ops/modules/pipeline/main.tf
@@ -16,10 +16,8 @@ resource "aws_codestarconnections_connection" "repo_actions" {
   provider_type = "GitHub"
 }
 
-data "template_file" "buildspec" {
-  template = file("${path.module}/buildspec.yml")
-
-  vars = {
+locals {
+  buildspec = templatefile("${path.module}/buildspec.yml", {
     ecr_repository_url = var.ecr_repository_url
     ecr_project_uri    = var.ecr_project_uri
     region             = var.region
@@ -29,7 +27,7 @@ data "template_file" "buildspec" {
     rollbar_env        = var.environment_name
     docker_username    = var.docker_username
     docker_password    = var.docker_password
-  }
+  })
 }
 
 resource "aws_codebuild_project" "codebuild_project" {
@@ -50,7 +48,7 @@ resource "aws_codebuild_project" "codebuild_project" {
 
   source {
     type      = "CODEPIPELINE"
-    buildspec = data.template_file.buildspec.rendered
+    buildspec = local.buildspec
   }
 }
 

--- a/ops/modules/pipeline/roles.tf
+++ b/ops/modules/pipeline/roles.tf
@@ -17,19 +17,17 @@ resource "aws_iam_role" "codepipeline_role" {
 EOF
 }
 
-data "template_file" "codepipeline_policy_template" {
-  template = file("${path.module}/policies/codepipeline_policy.json")
-
-  vars = {
+locals {
+  codepipeline_policy_template = templatefile("${path.module}/policies/codepipeline_policy.json", {
     aws_s3_bucket_arn       = aws_s3_bucket.pipeline_store.arn
     codestar_connection_arn = aws_codestarconnections_connection.repo_actions.arn
-  }
+  })
 }
 
 resource "aws_iam_role_policy" "codepipeline_policy" {
   name   = "${var.project_name}-${var.environment_name}-codepipeline-policy"
   role   = aws_iam_role.codepipeline_role.id
-  policy = data.template_file.codepipeline_policy_template.rendered
+  policy = local.codepipeline_policy_template
 }
 
 resource "aws_iam_role" "codebuild_role" {
@@ -50,17 +48,15 @@ resource "aws_iam_role" "codebuild_role" {
 EOF
 }
 
-data "template_file" "codebuild_policy_template" {
-  template = file("${path.module}/policies/codebuild_policy.json")
-
-  vars = {
+locals {
+  codebuild_policy_template = templatefile("${path.module}/policies/codebuild_policy.json", {
     aws_s3_bucket_arn = aws_s3_bucket.pipeline_store.arn
-  }
+  })
 }
 
 resource "aws_iam_role_policy" "codebuild_policy" {
   name   = "${var.project_name}-${var.environment_name}-codebuild-policy"
   role   = aws_iam_role.codebuild_role.id
-  policy = data.template_file.codebuild_policy_template.rendered
+  policy = local.codebuild_policy_template
 }
 

--- a/ops/production/.terraform.lock.hcl
+++ b/ops/production/.terraform.lock.hcl
@@ -19,20 +19,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
-  ]
-}

--- a/ops/production/.terraform.lock.hcl
+++ b/ops/production/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.70.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:7rt5BdmiBJOFlNHstjwg2tDP4b+/+4sSvjz5ywP4HJE=",
     "h1:jn4ImGMZJ9rQdaVSbcCBqUqnhRSpyaM1DivqaNuP+eg=",
     "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
     "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",

--- a/ops/production/main.tf
+++ b/ops/production/main.tf
@@ -98,6 +98,8 @@ module "application" {
   public_subnet_ids           = module.vpc.public_subnet_ids
   instance_type               = "t3.medium"
   desired_instance_count      = 2
+  service_memory              = "4GB"
+  service_cpu                 = 2048
   lb_target_group_arn         = module.load_balancer.lb_target_group_arn
   ssh_key_name                = "ec2_test_key"
   rails_master_key            = var.rails_master_key

--- a/ops/staging/.terraform.lock.hcl
+++ b/ops/staging/.terraform.lock.hcl
@@ -19,20 +19,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fc3f3cad84f2eebe566dd0b65904c934093007323b9b85e73d9dd4535ceeb29d",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
-  ]
-}

--- a/ops/staging/.terraform.lock.hcl
+++ b/ops/staging/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.70.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:7rt5BdmiBJOFlNHstjwg2tDP4b+/+4sSvjz5ywP4HJE=",
     "h1:jn4ImGMZJ9rQdaVSbcCBqUqnhRSpyaM1DivqaNuP+eg=",
     "zh:0af710e528e21b930899f0ac295b0ceef8ad7b623dd8f38e92c8ec4bc7af0321",
     "zh:4cabcd4519c0aae474d91ae67a8e3a4a8c39c3945c289a9cf7c1409f64409abe",

--- a/ops/staging/main.tf
+++ b/ops/staging/main.tf
@@ -104,7 +104,9 @@ module "application" {
   db_password                 = var.db_password
   public_subnet_ids           = module.vpc.public_subnet_ids
   desired_instance_count      = 1
-  instance_type               = "t2.small"
+  instance_type               = "t3.small"
+  service_memory              = "2GB"
+  service_cpu                 = 2048
   lb_target_group_arn         = module.load_balancer.lb_target_group_arn
   ssh_key_name                = "ec2_test_key"
   rails_master_key            = var.rails_master_key


### PR DESCRIPTION
We were artificially limiting the CPU and memory available to the app service running on ECS. I think we can go ahead and use the entire EC2 instance capacity to run the containers.