### PR TITLE
Reset recaptcha after page load

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    recaptcha (5.15.0)
+    recaptcha (5.16.0)
     redis (4.5.1)
     redis-namespace (1.8.2)
       redis (>= 3.0.4)

--- a/app/views/devise/registrations/_new.html.erb
+++ b/app/views/devise/registrations/_new.html.erb
@@ -111,6 +111,14 @@
       <%= recaptcha_tags %>
     </div>
 
+    <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', function () {
+        grecaptcha.ready(function() {
+          grecaptcha.reset();
+        });
+      });
+    </script>
+
     <%= f.submit t("home.signup"), class: "button-color" %>
 
   <% end %>

--- a/app/views/devise/registrations/_new.html.erb
+++ b/app/views/devise/registrations/_new.html.erb
@@ -114,7 +114,12 @@
     <script type="text/javascript">
       document.addEventListener('DOMContentLoaded', function () {
         grecaptcha.ready(function() {
-          grecaptcha.reset();
+          // Hacky solution to reset the recaptcha
+          // For some reason, recaptcha V2 started failing silently.
+          // This is the only thing that seems to fix it.
+          setTimeout(function() {
+            grecaptcha.reset();
+          }, 500);
         });
       });
     </script>


### PR DESCRIPTION
Recaptcha v2 started spinning & silently failing to open the verification modal. This seems to fix it.